### PR TITLE
Update dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "phpseclib/phpseclib": "2.0.18"
+        "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
This hard dependency restricts upgrading to the latest stable release.

There are some php7.4 incompatibilities with version 2.0.18 of phpseclib that the sdk depends on.