### PR TITLE
Update CnpXmlMapper.php

### DIFF
--- a/cnp/sdk/CnpXmlMapper.php
+++ b/cnp/sdk/CnpXmlMapper.php
@@ -30,7 +30,7 @@ class CnpXmlMapper
     {
     }
 
-    public function request($request,$hash_config=NULL,$useSimpleXml)
+    public function request($request,$hash_config=NULL,$useSimpleXml=FALSE)
     {
         $response = Communication::httpRequest($request,$hash_config);
         if ($useSimpleXml) {


### PR DESCRIPTION
Starting with php 8.0.x, having required method parameters AFTER optional method parameters is deprecated, and issues a warning.