### PR TITLE
Update CnpXmlMapper.php

### DIFF
--- a/cnp/sdk/CnpXmlMapper.php
+++ b/cnp/sdk/CnpXmlMapper.php
@@ -30,7 +30,7 @@ class CnpXmlMapper
     {
     }
 
-    public function request($request,$hash_config=NULL,$useSimpleXml)
+    public function request($request,$hash_config,$useSimpleXml)
     {
         $response = Communication::httpRequest($request,$hash_config);
         if ($useSimpleXml) {


### PR DESCRIPTION
PHP 8 has deprecated putting mandatory parameters after optional parameters.  Which makes sense, because any optional param listed BEFORE a required param becomes a required param...