### PR TITLE
Update CnpXmlMapper.php for php 8.x compliance

### DIFF
--- a/cnp/sdk/CnpXmlMapper.php
+++ b/cnp/sdk/CnpXmlMapper.php
@@ -30,7 +30,7 @@ class CnpXmlMapper
     {
     }
 
-    public function request($request,$hash_config=NULL,$useSimpleXml)
+    public function request($request,$hash_config=NULL,$useSimpleXml=FALSE)
     {
         $response = Communication::httpRequest($request,$hash_config);
         if ($useSimpleXml) {


### PR DESCRIPTION
In PHP 8.x, having required parameters AFTER optional parameters results in a deprecation warning.  It also doesn't make sense to do it in the first place.  Having a required param after an optional one makes the optional one required.  Fixes issue #37 