### PR TITLE
Change phpseclib dependency to allow for patch level updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "phpseclib/phpseclib": "3.0.20"
+        "phpseclib/phpseclib": "~3.0.35"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
The purpose of this pull request is to allow patch level updates of phpseclib (to avoid security vulnerabilities) and bring it to version 3.0.35, since version 3.0.20 (currently required by Vantiv/cnp-sdk-for-php) has an open security vulnerability.

The ~ in the composer.json file will allow updates up to 3.0.X, but not 3.1.X.  This will ensure there are no breaking changes, but allow patch level updates.

I also noticed the composer.lock file is in the .gitignore file.  I would advise against that, and have it be part of your repository, so you know the exact versions you successfully tested with in lower environments are the same ones installed in production.  Of course if you are building containers, that may not be necessary.

Fixes Issue: https://github.com/Vantiv/cnp-sdk-for-php/issues/49