### PR TITLE
Upgrade PHP SDK v12.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 = CnpOnline CHANGELOG
 
+==Version 12.40.0 (v12.40.0)(October 25, 2024)
+* Change: [cnpAPI v12.40] In authorization,sale and captureGivenAuth request new elements added-> 'typeOfDigitalCurrency' and 'conversionAffiliateId'.
+* Change: [cnpAPI v12.40] In existing simple type transactionAmountType range added between minInclusive value -999999999999  and maxInclusive value 999999999999
+* Change: [cnpAPI v12.40] In existing type authenticationProtocolVersionType new values '3','4','5','6','7','8' and '9' are added
+
+==Version 12.39.0 (v12.39.0) (October 25, 2024)
+* Change: [cnpAPI v12.39] In 'subMerchantCredit' 'payFacCredit','reserveCredit', 'payoutOrgCreditRequest' base changed from 'transactionTypeWithReportGroup' to 'transactionTypeWithReportGroupAndRtp'.
+* Change: [cnpAPI v12.39] To support new changed extension base for above txns ,New Complextype 'transactionTypeWithReportGroupAndRtp' added.
+* Change: [cnpAPI v12.39] New element 'fundingTransactionReferenceNumber' in authorization and sale response.
+
+==Version 12.38.0 (v12.38.0) (October 25, 2024)
+* Change: [cnpAPI v12.38] In existing Enum 'ActionTypeEnum' new value 'FIVD' added
+* Change: [cnpAPI v12.38] In existing complex element 'baseRequest' two more choices are added 'encryptionKeyRequest' and 'encryptedPayload'
+* Change: [cnpAPI v12.38] In existing complex element 'cnpOnlineResponse' one more choice is added 'encryptionKeyResponse'
+* Change: [cnpAPI v12.38] New element 'encryptionKeyRequest' is added of type 'encryptionKeyRequestEnum'
+* Change: [cnpAPI v12.38] To support 'encryptionKeyRequest' new Enum 'encryptionKeyRequestEnum' added with values 'CURRENT' and 'PREVIOUS'
+* Change: [cnpAPI v12.38] New complex element 'encryptionKeyResponse' is added with simple elements ->'encryptionKeySequence' of type 'encryptionKeySequenceType' and 'encryptionKey' of type 'encryptionKeyType'
+* Change: [cnpAPI v12.38] To support 'encryptionKeySequence' new simple type 'encryptionKeySequenceType' added with total Digits 19
+* Change: [cnpAPI v12.38] To support 'encryptionKey' new simple type 'encryptionKeyType' of type string with maxLength 15000
+* Change: [cnpAPI v12.38] New complex element 'encryptedPayload' is added with simple elements ->'encryptionKeySequence' of type 'encryptionKeySequenceType' and 'payload' of type 'payloadType'
+* Change: [cnpAPI v12.38] To support 'payload' new simple type 'payloadType' of type string with maxLength 15000
+* Change: [cnpAPI v12.38] In capture Request new complex element 'partialCapture' is added with elements-> 'partialCaptureSequenceNumber' of type 'integer' and 'partialCaptureTotalCount' of type 'partialCaptureCount'
+
 ==Version 12.37.1 (v12.37.1)(July 29, 2024)
 Fix: [cnpAPI v12.37.1] Fix for Ordering issue for Fast Access Funding
 

--- a/cnp/sdk/Checker.php
+++ b/cnp/sdk/Checker.php
@@ -36,7 +36,7 @@ class Checker
     public static function validateXML($request){
         $xml = new DOMDocument();
         $xml->loadXML($request);
-        $filepath = __DIR__ . "/schema/SchemaCombined_v12.37.xsd";
+        $filepath = __DIR__ . "/schema/SchemaCombined_v12.40.xsd";
         $result =  $xml->schemaValidate( $filepath);
 
         if(!$result)

--- a/cnp/sdk/CnpOnline.php
+++ b/cnp/sdk/CnpOnline.php
@@ -28,5 +28,5 @@ define('CURRENT_XML_VERSION', '12.40');
 define('CURRENT_SDK_VERSION', 'PHP;12.40.0');
 define('MAX_TXNS_PER_BATCH', 100000);
 define('MAX_TXNS_PER_REQUEST', 500000);
-define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout');
+define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout,oltpEncryptionKeySequence,oltpEncryptionPayload,oltpEncryptionKeyPath');
 

--- a/cnp/sdk/CnpOnline.php
+++ b/cnp/sdk/CnpOnline.php
@@ -24,8 +24,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 namespace cnp\sdk;
-define('CURRENT_XML_VERSION', '12.37');
-define('CURRENT_SDK_VERSION', 'PHP;12.37.1');
+define('CURRENT_XML_VERSION', '12.40');
+define('CURRENT_SDK_VERSION', 'PHP;12.40.0');
 define('MAX_TXNS_PER_BATCH', 100000);
 define('MAX_TXNS_PER_REQUEST', 500000);
 define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout');

--- a/cnp/sdk/CnpOnline.php
+++ b/cnp/sdk/CnpOnline.php
@@ -28,5 +28,5 @@ define('CURRENT_XML_VERSION', '12.40');
 define('CURRENT_SDK_VERSION', 'PHP;12.40.0');
 define('MAX_TXNS_PER_BATCH', 100000);
 define('MAX_TXNS_PER_REQUEST', 500000);
-define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout,oltpEncryptionKeySequence,oltpEncryptionPayload,oltpEncryptionKeyPath');
+define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,neuter_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout,oltpEncryptionKeySequence,oltpEncryptionPayload,oltpEncryptionKeyPath');
 

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -148,7 +148,9 @@ class CnpOnlineRequest
                 'passengerTransportData' => XmlFields::passengerTransportData(XmlFields::returnArrayValue($hash_in, 'passengerTransportData')),
                 'authIndicator' => XmlFields::returnArrayValue($hash_in, 'authIndicator'),
                 'accountFundingTransactionData' => XmlFields::accountFundingTransactionData(XmlFields::returnArrayValue($hash_in, 'accountFundingTransactionData')),
-                'fraudCheckAction' => XmlFields::returnArrayValue($hash_in, 'fraudCheckAction')
+                'typeOfDigitalCurrency' => XmlFields::returnArrayValue($hash_in, 'typeOfDigitalCurrency'),
+                'conversionAffiliateId' => XmlFields::returnArrayValue($hash_in, 'conversionAffiliateId'),
+
             );
         }
         $choice_hash = array(XmlFields::returnArrayValue($hash_out, 'card'), XmlFields::returnArrayValue($hash_out, 'paypal'), XmlFields::returnArrayValue($hash_out, 'token'), XmlFields::returnArrayValue($hash_out, 'paypage'), XmlFields::returnArrayValue($hash_out, 'applepay'), XmlFields::returnArrayValue($hash_out, 'mpos'));
@@ -230,7 +232,10 @@ class CnpOnlineRequest
             'passengerTransportData' => XmlFields::passengerTransportData(XmlFields::returnArrayValue($hash_in, 'passengerTransportData')),
             'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
             'accountFundingTransactionData' => XmlFields::accountFundingTransactionData(XmlFields::returnArrayValue($hash_in, 'accountFundingTransactionData')),
-            'fraudCheckAction' => XmlFields::returnArrayValue($hash_in, 'fraudCheckAction')
+            'fraudCheckAction' => XmlFields::returnArrayValue($hash_in, 'fraudCheckAction'),
+            'typeOfDigitalCurrency' => XmlFields::returnArrayValue($hash_in, 'typeOfDigitalCurrency'),
+            'conversionAffiliateId' => XmlFields::returnArrayValue($hash_in, 'conversionAffiliateId'),
+
         );
 
         $choice_hash = array($hash_out['card'], $hash_out['paypal'], $hash_out['token'], $hash_out['paypage'], $hash_out['applepay'], $hash_out['mpos']);
@@ -468,7 +473,9 @@ class CnpOnlineRequest
             'lodgingInfo' => XmlFields::lodgingInfo(XmlFields::returnArrayValue($hash_in, 'lodgingInfo')),
             'pin' => XmlFields::returnArrayValue($hash_in, 'pin'),
             'passengerTransportData' => XmlFields::passengerTransportData(XmlFields::returnArrayValue($hash_in, 'passengerTransportData')),
-            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator')
+            'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
+            'partialCapture' => XmlFields::returnArrayValue($hash_in, 'partialCapture')
+
         );
         $captureResponse = $this->processRequest($hash_out, $hash_in, 'capture');
 
@@ -516,7 +523,10 @@ class CnpOnlineRequest
             'crypto' => XmlFields::returnArrayValue($hash_in, 'crypto'),
             'passengerTransportData' => XmlFields::passengerTransportData(XmlFields::returnArrayValue($hash_in, 'passengerTransportData')),
             'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
-            'accountFundingTransactionData' => XmlFields::accountFundingTransactionData(XmlFields::returnArrayValue($hash_in, 'accountFundingTransactionData'))
+            'accountFundingTransactionData' => XmlFields::accountFundingTransactionData(XmlFields::returnArrayValue($hash_in, 'accountFundingTransactionData')),
+            'typeOfDigitalCurrency' => XmlFields::returnArrayValue($hash_in, 'typeOfDigitalCurrency'),
+            'conversionAffiliateId' => XmlFields::returnArrayValue($hash_in, 'conversionAffiliateId'),
+
         );
 
         $choice_hash = array($hash_out['card'], $hash_out['token'], $hash_out['paypage'], $hash_out['mpos']);

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -28,6 +28,7 @@ namespace cnp\sdk;
 use DOMDocument;
 use XSLTProcessor;
 use SimpleXMLElement;
+use SplFileInfo;
 require_once realpath(dirname(__FILE__)) . '/CnpOnline.php';
 
 class CnpOnlineRequest
@@ -1545,7 +1546,7 @@ class CnpOnlineRequest
         $hash_config = CnpOnlineRequest::overrideConfig($hash_in);
         $hash = CnpOnlineRequest::getOptionalAttributes($hash_in, $hash_out);
         $request = Obj2xml::toXml($hash, $hash_config, $type);
-        $config= Obj2xml::getConfig($hash_config, $type);
+        $config = Obj2xml::getConfig(array());
         if (Checker::validateXML($request)) {
             $request = str_replace("submerchantDebitCtx", "submerchantDebit", $request);
             $request = str_replace("submerchantCreditCtx", "submerchantCredit", $request);
@@ -1585,14 +1586,14 @@ class CnpOnlineRequest
         return $encryptionKeyResponse;
     }
 
-    public  function getPayloadElement($request)
+    public function getPayloadElement($request)
     {
         try {
             $doc = new DOMDocument('1.0', 'UTF-8');
             $doc->loadXML($request);
             $root = $doc->documentElement;
             $payload = '';
-            $config= Obj2xml::getConfig($hash_config, $type);
+            $config = Obj2xml::getConfig(array());
             $path = $config['oltpEncryptionKeyPath'];
 
             $secondChild = $root->childNodes->item(1);
@@ -1604,25 +1605,32 @@ class CnpOnlineRequest
                 if ($secondChild->nodeName === 'encryptionKeyRequest') {
                     return $xmlRequest;
                 } else {
-                    $output = $doc->saveXML($secondChild);
-                    $output = trim($output);
+                    if ($path == null) {
+                        throw new Exception('Problem in reading the Encryption Key path. Provide the Encryption key path.');
+                    } else {
+                        $path = new SplFileInfo($path);
+                        if (!$path->isFile()) {
+                            throw new VantivException("The provided path is not a valid file path or the file does not exist.");
+                        }
+                    }
+
+                     $output = $doc->saveXML($secondChild);
+                     $output = trim($output);
 
                     if ($secondChild !== null) {
                         $root->removeChild($secondChild);
                     }
 
-                    $payload = PgpHelper::onlineEncrypt($output, $path);
+                    $payload = PgpHelper::encryptPayload($output, $path);
 
                     $encryptedPayloadElement = $doc->createElement('encryptedPayload');
 
                     // Create and append the encryptionKeySequence element
                     $encryptionKeySequenceElement = $doc->createElement('encryptionKeySequence');
 
-                    if ((int) $config['oltpEncryptionKeySequence'] !== null){
-                        $encryptionKeySequenceElement->nodeValue = (int) $config['oltpEncryptionKeySequence'];
-
-                    }
-                    else{
+                    if ((int)$config['oltpEncryptionKeySequence'] !== null) {
+                        $encryptionKeySequenceElement->nodeValue = (int)$config['oltpEncryptionKeySequence'];
+                   } else{
                         throw new Exception('Problem in reading the Encryption Key Sequence ...Provide the Encryption key Sequence');
                     }
                     $encryptedPayloadElement->appendChild($encryptionKeySequenceElement);

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -1583,7 +1583,7 @@ class CnpOnlineRequest
             $request = str_replace("submerchantCreditCtx", "submerchantCredit", $request);
             $request = str_replace("vendorCreditCtx", "vendorCredit", $request);
             $request = str_replace("vendorDebitCtx", "vendorDebit", $request);
-            if ($hash_config['oltpEncryptionPayload']){
+            if ((int)$hash_config['oltpEncryptionPayload'] == 1){
                 $request = CnpOnlineRequest::getPayloadElement($request);
             }
             $cnpOnlineResponse = $this->newXML->request($request, $hash_config, $this->useSimpleXml);
@@ -1608,7 +1608,7 @@ class CnpOnlineRequest
                 // Transform the second element to a string
                 $output = '';
 
-                if ($secondChild->nodeName === 'encryptionKeyRequest') {
+                if ($secondChild->nodeName == 'encryptionKeyRequest') {
                     return $request;
                 } else {
                     if ($path == null) {

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -28,6 +28,8 @@ namespace cnp\sdk;
 use DOMDocument;
 use XSLTProcessor;
 use SimpleXMLElement;
+use SplFileInfo;
+use Exception;
 require_once realpath(dirname(__FILE__)) . '/CnpOnline.php';
 
 class CnpOnlineRequest
@@ -1545,13 +1547,14 @@ class CnpOnlineRequest
         $hash_config = CnpOnlineRequest::overrideConfig($hash_in);
         $hash = CnpOnlineRequest::getOptionalAttributes($hash_in, $hash_out);
         $request = Obj2xml::toXml($hash, $hash_config, $type);
-        $config= Obj2xml::getConfig(array());
+
         if (Checker::validateXML($request)) {
             $request = str_replace("submerchantDebitCtx", "submerchantDebit", $request);
             $request = str_replace("submerchantCreditCtx", "submerchantCredit", $request);
             $request = str_replace("vendorCreditCtx", "vendorCredit", $request);
             $request = str_replace("vendorDebitCtx", "vendorDebit", $request);
-            if ((int) $config['oltpEncryptionPayload']){
+            $config= Obj2xml::getConfig(array());
+            if ($config['oltpEncryptionPayload']){
                 $request = CnpOnlineRequest::getPayloadElement($request);
             }
             $cnpOnlineResponse = $this->newXML->request($request, $hash_config, $this->useSimpleXml);
@@ -1602,7 +1605,7 @@ class CnpOnlineRequest
                 $output = '';
 
                 if ($secondChild->nodeName === 'encryptionKeyRequest') {
-                    return $xmlRequest;
+                    return $request;
                 } else {
                     if ($path == null) {
                         throw new Exception('Problem in reading the Encryption Key path. Provide the Encryption key path.');
@@ -1626,8 +1629,7 @@ class CnpOnlineRequest
 
                     // Create and append the encryptionKeySequence element
                     $encryptionKeySequenceElement = $doc->createElement('encryptionKeySequence');
-
-                    if ((int)$config['oltpEncryptionKeySequence'] !== null) {
+                    if ($config['oltpEncryptionKeySequence']) {
                         $encryptionKeySequenceElement->nodeValue = (int)$config['oltpEncryptionKeySequence'];
                     } else{
                         throw new Exception('Problem in reading the Encryption Key Sequence ...Provide the Encryption key Sequence');

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -1545,6 +1545,7 @@ class CnpOnlineRequest
     private function processRequest($hash_out, $hash_in, $type, $choice1 = null, $choice2 = null)
     {
         $hash_config = CnpOnlineRequest::overrideConfig($hash_in);
+        $hash_config= Obj2xml::getConfig($hash_config);
         $hash = CnpOnlineRequest::getOptionalAttributes($hash_in, $hash_out);
         $request = Obj2xml::toXml($hash, $hash_config, $type);
 
@@ -1553,8 +1554,7 @@ class CnpOnlineRequest
             $request = str_replace("submerchantCreditCtx", "submerchantCredit", $request);
             $request = str_replace("vendorCreditCtx", "vendorCredit", $request);
             $request = str_replace("vendorDebitCtx", "vendorDebit", $request);
-            $config= Obj2xml::getConfig(array());
-            if ($config['oltpEncryptionPayload']){
+            if ($hash_config['oltpEncryptionPayload']){
                 $request = CnpOnlineRequest::getPayloadElement($request);
             }
             $cnpOnlineResponse = $this->newXML->request($request, $hash_config, $this->useSimpleXml);

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -1492,6 +1492,35 @@ class CnpOnlineRequest
 
     /**
      * @param $hash_in
+     * @return \DOMDocument|\SimpleXMLElement
+     * @throws exceptions\cnpSDKException
+     */
+    public function encryptionKeyRequest($hash_in)
+    {
+        $hash_out = array(XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
+        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptionKeyRequest');
+
+        return $encryptionKeyResponse;
+    }
+
+    /**
+     * @param $hash_in
+     * @return \DOMDocument|\SimpleXMLElement
+     * @throws exceptions\cnpSDKException
+     */
+    public function encryptedPayload($hash_in)
+    {
+        $hash_out = array(
+            'encryptionKeySequence' => (XmlFields::returnArrayValue($hash_in, 'encryptionKeySequence')),
+            'payload' => (XmlFields::returnArrayValue($hash_in, 'payload')),
+        );
+        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptedPayload');
+
+        return $encryptionKeyResponse;
+    }
+
+    /**
+     * @param $hash_in
      * @return array
      */
     private static function overrideConfig($hash_in)
@@ -1563,31 +1592,6 @@ class CnpOnlineRequest
         return $cnpOnlineResponse;
     }
 
-    public function encryptionKeyRequest($hash_in)
-    {
-        $hash_out = array(XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
-        // $hash_out = array('encryptionKeyRequest' => XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
-        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptionKeyRequest');
-
-        return $encryptionKeyResponse;
-    }
-
-    /**
-     * @param $hash_in
-     * @return \DOMDocument|\SimpleXMLElement
-     * @throws exceptions\cnpSDKException
-     */
-    public function encryptedPayload($hash_in)
-    {
-        $hash_out = array(
-            'encryptionKeySequence' => (XmlFields::returnArrayValue($hash_in, 'encryptionKeySequence')),
-            'payload' => (XmlFields::returnArrayValue($hash_in, 'payload')),
-        );
-        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptedPayload');
-
-        return $encryptionKeyResponse;
-    }
-
     public function getPayloadElement($request)
     {
         try {
@@ -1612,7 +1616,7 @@ class CnpOnlineRequest
                     } else {
                         $path = new SplFileInfo($path);
                         if (!$path->isFile()) {
-                            throw new VantivException("The provided path is not a valid file path or the file does not exist.");
+                            throw new Exception("The provided path is not a valid file path or the file does not exist.");
                         }
                     }
 

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -148,6 +148,7 @@ class CnpOnlineRequest
                 'passengerTransportData' => XmlFields::passengerTransportData(XmlFields::returnArrayValue($hash_in, 'passengerTransportData')),
                 'authIndicator' => XmlFields::returnArrayValue($hash_in, 'authIndicator'),
                 'accountFundingTransactionData' => XmlFields::accountFundingTransactionData(XmlFields::returnArrayValue($hash_in, 'accountFundingTransactionData')),
+                'fraudCheckAction' => XmlFields::returnArrayValue($hash_in, 'fraudCheckAction'),
                 'typeOfDigitalCurrency' => XmlFields::returnArrayValue($hash_in, 'typeOfDigitalCurrency'),
                 'conversionAffiliateId' => XmlFields::returnArrayValue($hash_in, 'conversionAffiliateId'),
 
@@ -474,7 +475,7 @@ class CnpOnlineRequest
             'pin' => XmlFields::returnArrayValue($hash_in, 'pin'),
             'passengerTransportData' => XmlFields::passengerTransportData(XmlFields::returnArrayValue($hash_in, 'passengerTransportData')),
             'foreignRetailerIndicator' => XmlFields::returnArrayValue($hash_in, 'foreignRetailerIndicator'),
-            'partialCapture' => XmlFields::returnArrayValue($hash_in, 'partialCapture')
+            'partialCapture' => XmlFields::partialCapture(XmlFields::returnArrayValue($hash_in, 'partialCapture')),
 
         );
         $captureResponse = $this->processRequest($hash_out, $hash_in, 'capture');

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -1555,4 +1555,30 @@ class CnpOnlineRequest
         return $cnpOnlineResponse;
     }
 
+    public function encryptionKeyRequest($hash_in)
+    {
+        $hash_out = (XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
+       // $hash_out = array('encryptionKeyRequest' => XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
+        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptionKeyRequest');
+
+        return $encryptionKeyResponse;
+    }
+
+    /**
+     * @param $hash_in
+     * @return \DOMDocument|\SimpleXMLElement
+     * @throws exceptions\cnpSDKException
+     */
+    public function encryptedPayload($hash_in)
+    {
+        $hash_out = array(
+            'encryptionKeySequence' => (XmlFields::returnArrayValue($hash_in, 'encryptionKeySequence')),
+            'payload' => (XmlFields::returnArrayValue($hash_in, 'payload')),
+        );
+        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptedPayload');
+
+        return $encryptionKeyResponse;
+    }
+
+
 }

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -1490,6 +1490,34 @@ class CnpOnlineRequest
 
     /**
      * @param $hash_in
+     * @return \DOMDocument|\SimpleXMLElement
+     * @throws exceptions\cnpSDKException
+     */
+    public function encryptionKeyRequest($hash_in)
+    {
+        $hash_out = array(XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
+        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptionKeyRequest');
+        return $encryptionKeyResponse;
+    }
+
+    /**
+     * @param $hash_in
+     * @return \DOMDocument|\SimpleXMLElement
+     * @throws exceptions\cnpSDKException
+     */
+    public function encryptedPayload($hash_in)
+    {
+        $hash_out = array(
+            'encryptionKeySequence' => (XmlFields::returnArrayValue($hash_in, 'encryptionKeySequence')),
+            'payload' => (XmlFields::returnArrayValue($hash_in, 'payload')),
+        );
+        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptedPayload');
+
+        return $encryptionKeyResponse;
+    }
+
+    /**
+     * @param $hash_in
      * @return array
      */
     private static function overrideConfig($hash_in)
@@ -1552,7 +1580,7 @@ class CnpOnlineRequest
             $request = str_replace("vendorCreditCtx", "vendorCredit", $request);
             $request = str_replace("vendorDebitCtx", "vendorDebit", $request);
             if ((int) $config['oltpEncryptionPayload']){
-                $request = CnpOnlineRequest::getPayloadElement($request);
+                $request = CnpOnlineRequest::getPayloadElement($request,$hash_config);
             }
             $cnpOnlineResponse = $this->newXML->request($request, $hash_config, $this->useSimpleXml);
         }
@@ -1560,39 +1588,14 @@ class CnpOnlineRequest
         return $cnpOnlineResponse;
     }
 
-    public function encryptionKeyRequest($hash_in)
-    {
-        $hash_out = array(XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
-        // $hash_out = array('encryptionKeyRequest' => XmlFields::returnArrayValue($hash_in,'encryptionKeyRequest'));
-        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptionKeyRequest');
-
-        return $encryptionKeyResponse;
-    }
-
-    /**
-     * @param $hash_in
-     * @return \DOMDocument|\SimpleXMLElement
-     * @throws exceptions\cnpSDKException
-     */
-    public function encryptedPayload($hash_in)
-    {
-        $hash_out = array(
-            'encryptionKeySequence' => (XmlFields::returnArrayValue($hash_in, 'encryptionKeySequence')),
-            'payload' => (XmlFields::returnArrayValue($hash_in, 'payload')),
-        );
-        $encryptionKeyResponse = $this->processRequest($hash_out, $hash_in, 'encryptedPayload');
-
-        return $encryptionKeyResponse;
-    }
-
-    public  function getPayloadElement($request)
+    public  function getPayloadElement($request,$hash_config)
     {
         try {
             $doc = new DOMDocument('1.0', 'UTF-8');
             $doc->loadXML($request);
             $root = $doc->documentElement;
             $payload = '';
-            $config= Obj2xml::getConfig($hash_config, $type);
+            $config= Obj2xml::getConfig($hash_config);
             $path = $config['oltpEncryptionKeyPath'];
 
             $secondChild = $root->childNodes->item(1);
@@ -1602,7 +1605,7 @@ class CnpOnlineRequest
                 $output = '';
 
                 if ($secondChild->nodeName === 'encryptionKeyRequest') {
-                    return $xmlRequest;
+                    return $request;
                 } else {
                     $output = $doc->saveXML($secondChild);
                     $output = trim($output);

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -1583,6 +1583,8 @@ class CnpOnlineRequest
             $request = str_replace("submerchantCreditCtx", "submerchantCredit", $request);
             $request = str_replace("vendorCreditCtx", "vendorCredit", $request);
             $request = str_replace("vendorDebitCtx", "vendorDebit", $request);
+
+            // If oltpEncryptionPayload enabled then send reuqest for encryption.
             if (isset($hash_config['oltpEncryptionPayload']) and (int)$hash_config['oltpEncryptionPayload'] == 1){
                 $request = CnpOnlineRequest::getEncryptedPayload($request,$hash_config);
             }
@@ -1599,11 +1601,12 @@ class CnpOnlineRequest
             $doc->loadXML($request);
             $root = $doc->documentElement;
 
+            // Find the second child element
             $secondChild = $root->childNodes->item(1);
 
             if ($secondChild !== null) {
-                // Transform the second element to a string
 
+                // Skip the encrypt payload part for encryptionKeyRequest
                 if ($secondChild->nodeName == 'encryptionKeyRequest') {
                     return $request;
 
@@ -1623,9 +1626,10 @@ class CnpOnlineRequest
 
                     $output = $doc->saveXML($secondChild);
 
-
+                    // removing the child element which needs to be encrypted.
                     $root->removeChild($secondChild);
 
+                    //Send payload for encryption
                     $payload = PgpHelper::encryptPayload($output, $path);
 
                     $encryptedPayloadElement = $doc->createElement('encryptedPayload');
@@ -1643,6 +1647,7 @@ class CnpOnlineRequest
                     $payloadElement->nodeValue = $payload;
                     $encryptedPayloadElement->appendChild($payloadElement);
 
+                    // adding new element after encryption
                     $root->appendChild($encryptedPayloadElement);
                     $xmlRequest = $doc->saveHTML();
                     return $xmlRequest;

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -35,7 +35,6 @@ require_once realpath(dirname(__FILE__)) . '/CnpOnline.php';
 class CnpOnlineRequest
 {
     private $useSimpleXml = false;
-    public $request_file;
 
     public function __construct($treeResponse = false)
     {

--- a/cnp/sdk/Communication.php
+++ b/cnp/sdk/Communication.php
@@ -30,8 +30,9 @@ class Communication
         $config = Obj2xml::getConfig($hash_config);
 
 
-        if ((int) $config['print_xml']) {
-            echo $req;
+        if ((int)$config['print_xml']) {
+            Communication::print_xml($req, $config['neuter_xml']);
+            #echo $req;
         }
         $ch = curl_init();
 
@@ -55,7 +56,6 @@ class Communication
         $output = curl_exec($ch);
 
 
-
         $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if (! $output) {
             if ($responseCode == 'CURLE_OPERATION_TIMEDOUT'){
@@ -75,4 +75,32 @@ class Communication
         }
 
     }
+
+    public static function neuter_xml($xml)
+    {
+        $neuter_str = "NEUTERED";
+        if ($xml === null) {
+            return $xml;
+        }
+        $xml = preg_replace("/<accNum>.*?<\/accNum>/", "<accNum>$neuter_str</accNum>", $xml);
+        $xml = preg_replace("/<user>.*?<\/user>/", "<user>$neuter_str</user>", $xml);
+        $xml = preg_replace("/<password>.*?<\/password>/", "<password>$neuter_str</password>", $xml);
+        $xml = preg_replace("/<track>.*?<\/track>/", "<track>$neuter_str</track>", $xml);
+        $xml = preg_replace("/<number>.*?<\/number>/", "<number>$neuter_str</number>", $xml);
+        $xml = preg_replace("/<cardValidationNum>.*?<\/cardValidationNum>/", "<cardValidationNum>$neuter_str</cardValidationNum>", $xml);
+
+        return $xml;
+    }
+
+    public static function print_xml($xml_request, $neuter_xml_flag)
+    {
+        $xml_to_log = $xml_request;
+        if ($neuter_xml_flag) {
+            $xml_to_log = Communication::neuter_xml($xml_to_log);
+        }
+        echo "Request XML: $xml_to_log\n";
+
+        return $xml_to_log;
+    }
+
 }

--- a/cnp/sdk/Communication.php
+++ b/cnp/sdk/Communication.php
@@ -31,7 +31,7 @@ class Communication
 
 
         if ((int)$config['print_xml']) {
-            Communication::print_xml($req, $config['neuter_xml']);
+            Communication::print_xml($req, (int)$config['neuter_xml']);
             #echo $req;
         }
         $ch = curl_init();
@@ -95,7 +95,7 @@ class Communication
     public static function print_xml($xml_request, $neuter_xml_flag)
     {
         $xml_to_log = $xml_request;
-        if ($neuter_xml_flag) {
+        if ($neuter_xml_flag == 1) {
             $xml_to_log = Communication::neuter_xml($xml_to_log);
         }
         echo "Request XML: $xml_to_log\n";

--- a/cnp/sdk/Communication.php
+++ b/cnp/sdk/Communication.php
@@ -31,7 +31,7 @@ class Communication
 
 
         if ((int)$config['print_xml']) {
-            Communication::print_xml($req, (int)$config['neuter_xml']);
+            Communication::print_xml($req, $config);
             #echo $req;
         }
         $ch = curl_init();
@@ -92,10 +92,11 @@ class Communication
         return $xml;
     }
 
-    public static function print_xml($xml_request, $neuter_xml_flag)
+    public static function print_xml($xml_request, $config)
     {
+
         $xml_to_log = $xml_request;
-        if ($neuter_xml_flag == 1) {
+        if (isset($config['neuter_xml']) and (int)$config['neuter_xml'] == 1) {
             $xml_to_log = Communication::neuter_xml($xml_to_log);
         }
         echo "Request XML: $xml_to_log\n";

--- a/cnp/sdk/Communication.php
+++ b/cnp/sdk/Communication.php
@@ -92,9 +92,9 @@ class Communication
         return $xml;
     }
 
+    //If neuter_xml flag enabled then neuter the sensitive data from the request xml
     public static function print_xml($xml_request, $config)
     {
-
         $xml_to_log = $xml_request;
         if (isset($config['neuter_xml']) and (int)$config['neuter_xml'] == 1) {
             $xml_to_log = Communication::neuter_xml($xml_to_log);

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -43,7 +43,7 @@ class Obj2xml
         $authentication->addChild('user',$config["user"]);
         $authentication->addChild('password',$config["password"]);
 
-        if ($type === "encryptionKeyRequest"){
+        if ($type == "encryptionKeyRequest"){
             $xml->addChild($type,$data[0]);
             return $xml->asXML();
         }
@@ -338,7 +338,7 @@ class Obj2xml
                 } elseif ($name == 'sftp_timeout') {
                     $config['sftp_timeout'] = isset($config_array['sftp_timeout'])? $config_array['sftp_timeout']:'720';
                 } else {
-                    if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload') and ($name != 'neuter_xml')) {
+                    if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload') and ($name != 'oltpEncryptionKeySequence') and ($name != 'oltpEncryptionKeyPath') and ($name != 'neuter_xml')) {
                         throw new \InvalidArgumentException("Missing Field /$name/");
                     }
                     $config[$name] = $config_array[$name];

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -341,7 +341,9 @@ class Obj2xml
                     if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload') and ($name != 'oltpEncryptionKeySequence') and ($name != 'oltpEncryptionKeyPath') and ($name != 'neuter_xml')) {
                         throw new \InvalidArgumentException("Missing Field /$name/");
                     }
-                    $config[$name] = $config_array[$name];
+                    if(isset($config_array[$name])){
+                        $config[$name] = $config_array[$name];
+                    }
                 }
             }
         }

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -338,7 +338,7 @@ class Obj2xml
                 } elseif ($name == 'sftp_timeout') {
                     $config['sftp_timeout'] = isset($config_array['sftp_timeout'])? $config_array['sftp_timeout']:'720';
                 } else {
-                    if ((!isset($config_array[$name])) and ($name != 'proxy')) {
+                    if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload')) {
                         throw new \InvalidArgumentException("Missing Field /$name/");
                     }
                     $config[$name] = $config_array[$name];

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -338,7 +338,7 @@ class Obj2xml
                 } elseif ($name == 'sftp_timeout') {
                     $config['sftp_timeout'] = isset($config_array['sftp_timeout'])? $config_array['sftp_timeout']:'720';
                 } else {
-                    if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload')) {
+                    if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload') and ($name != 'neuter_xml')) {
                         throw new \InvalidArgumentException("Missing Field /$name/");
                     }
                     $config[$name] = $config_array[$name];

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -43,7 +43,10 @@ class Obj2xml
         $authentication->addChild('user',$config["user"]);
         $authentication->addChild('password',$config["password"]);
 
-
+        if ($type === "encryptionKeyRequest"){
+            $xml->addChild($type,$data[0]);
+            return $xml->asXML();
+        }
 
         $transacType = $xml->addChild($type);
 

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -43,6 +43,7 @@ class Obj2xml
         $authentication->addChild('user',$config["user"]);
         $authentication->addChild('password',$config["password"]);
 
+        // If request type is encryptionKeyRequest then return xml with encryptionKeyRequest value.
         if ($type == "encryptionKeyRequest"){
             $xml->addChild($type,$data[0]);
             return $xml->asXML();
@@ -341,6 +342,7 @@ class Obj2xml
                     if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload') and ($name != 'oltpEncryptionKeySequence') and ($name != 'oltpEncryptionKeyPath') and ($name != 'neuter_xml')) {
                         throw new \InvalidArgumentException("Missing Field /$name/");
                     }
+                    // If encryptionPayload properties are not available in config file then add other properties.
                     if(isset($config_array[$name])){
                         $config[$name] = $config_array[$name];
                     }

--- a/cnp/sdk/PgpHelper.php
+++ b/cnp/sdk/PgpHelper.php
@@ -58,9 +58,10 @@ class PgpHelper
         return rtrim($split[2], ":");
     }
 
-    public static function encryptPayload($encryptInput, $publicKey)
-    {
+    public static function onlineEncrypt($encryptInput, $publicKey) {
         // Open a process to gpg with pipes
+       // $byte_array = unpack('C*', $encryptInput);
+       // $base64Encoded = base64_encode($encryptInput);
         $descriptorspec = [
             0 => ["pipe", "r"],  // stdin is a pipe that the child will read from
             1 => ["pipe", "w"],  // stdout is a pipe that the child will write to
@@ -86,11 +87,11 @@ class PgpHelper
             $return_value = proc_close($process);
 
             if ($return_value != 0) {
-                throw new \RuntimeException("Encrypting the payload has failed" . $errors);
+                throw new \RuntimeException("The string could not be encrypted. Check the public key entered. " . $errors);
             }
             return $encryptedString;
         } else {
-            throw new \RuntimeException("Encrypting the payload has failed. Please check the Encryption key or key path, is correct!\n");
+            throw new \RuntimeException("Failed to open process for encryption.");
         }
     }
 }

--- a/cnp/sdk/PgpHelper.php
+++ b/cnp/sdk/PgpHelper.php
@@ -58,10 +58,9 @@ class PgpHelper
         return rtrim($split[2], ":");
     }
 
-    public static function onlineEncrypt($encryptInput, $publicKey) {
+    public static function encryptPayload($encryptInput, $publicKey)
+    {
         // Open a process to gpg with pipes
-       // $byte_array = unpack('C*', $encryptInput);
-       // $base64Encoded = base64_encode($encryptInput);
         $descriptorspec = [
             0 => ["pipe", "r"],  // stdin is a pipe that the child will read from
             1 => ["pipe", "w"],  // stdout is a pipe that the child will write to
@@ -87,11 +86,11 @@ class PgpHelper
             $return_value = proc_close($process);
 
             if ($return_value != 0) {
-                throw new \RuntimeException("The string could not be encrypted. Check the public key entered. " . $errors);
+                throw new \RuntimeException("Encrypting the payload has failed" . $errors);
             }
             return $encryptedString;
         } else {
-            throw new \RuntimeException("Failed to open process for encryption.");
+            throw new \RuntimeException("Encrypting the payload has failed. Please check the Encryption key or key path, is correct!\n");
         }
     }
 }

--- a/cnp/sdk/Setup.php
+++ b/cnp/sdk/Setup.php
@@ -99,6 +99,7 @@ function initialize()
         # ssl should be usd by default
         $line['tcp_ssl'] = '1';
         $line['print_xml'] = '0';
+        $line['neuter_xml'] = '1';
         print "Use PGP encryption for batch files? (y/n) (No encryption by default): ";
         $useEncryption = formatConfigValue(STDIN);
         if(("y" == $useEncryption) || ("true" == $useEncryption) || ("yes" == $useEncryption)){

--- a/cnp/sdk/Setup.php
+++ b/cnp/sdk/Setup.php
@@ -130,6 +130,22 @@ function initialize()
         $line['multiSiteErrorThreshold'] = '5';
         $line['maxHoursWithoutSwitch'] = '48';
         $line['deleteBatchFiles'] = "";
+
+        print "Please input your oltpEncryptionPayload (true/false) (No encryption by default): ";
+        $oltpEncryptionPayload = trim(fgets(STDIN));
+        $line['oltpEncryptionPayload'] = $oltpEncryptionPayload;
+        $booleanValue = filter_var(strtolower($oltpEncryptionPayload), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if  ($booleanValue){
+            print "Please input your oltpEncryptionKeySequence: ";
+            $line['oltpEncryptionKeySequence'] = formatConfigValue(STDIN);
+            print "Please input your oltpEncryptionKeyPath: ";
+            $line['oltpEncryptionKeyPath '] = formatConfigValue(STDIN);
+        }else{
+            $line['oltpEncryptionPayload'] = "";
+            $line['oltpEncryptionKeySequence'] = "";
+            $line['oltpEncryptionKeyPath '] = "";
+        }
+
         writeConfig($line,$handle);
         #default http timeout set to 500 ms
         fwrite($handle, "timeout =  500".  PHP_EOL);

--- a/cnp/sdk/Setup.php
+++ b/cnp/sdk/Setup.php
@@ -142,7 +142,7 @@ function initialize()
             print "Please input your oltpEncryptionKeyPath: ";
             $line['oltpEncryptionKeyPath '] = formatConfigValue(STDIN);
         }else{
-            $line['oltpEncryptionPayload'] = "";
+            $line['oltpEncryptionPayload'] = "false";
             $line['oltpEncryptionKeySequence'] = "";
             $line['oltpEncryptionKeyPath '] = "";
         }

--- a/cnp/sdk/Test/functional/AuthFunctionalTest.php
+++ b/cnp/sdk/Test/functional/AuthFunctionalTest.php
@@ -1320,4 +1320,81 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
         $location = XmlParser::getNode($authorizationResponse, 'location');
         $this->assertEquals('sandbox', $location);
     }
+
+    public function test_simple_auth_with_DigitalCurrency()
+    {
+        $hash_in = array('id' => 'id',
+            'card' => array('type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'),
+            'id' => '1211',
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Smith',
+                'receiverState' => 'AZ',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '1234567890',
+                'accountFundingTransactionType' => 'walletTransfer',
+                'receiverAccountNumberType' => 'socialNetworkID'
+            ),
+            'typeOfDigitalCurrency' => '1',
+            'conversionAffiliateId' => 'Test',
+            'orderId' => '22@33',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'orderChannel' => 'SCAN_AND_GO',
+            'fraudCheckAction' => 'DECLINED_NEED_FRAUD_CHECK',
+            'amount' => '0',
+            'enhancedData' => array(
+                'detailTax0' => array(
+                    'taxAmount' => '200',
+                    'taxRate' => '0.06',
+                    'taxIncludedInTotal' => true
+                ),
+                'detailTax1' => array(
+                    'taxAmount' => '300',
+                    'taxRate' => '0.10',
+                    'taxIncludedInTotal' => true
+                ),'lineItemData0' => array(
+                    'itemSequenceNumber' => '1',
+                    'itemDescription' => 'product 1',
+                    'productCode' => '123',
+                    'quantity' => 3,
+                    'unitOfMeasure' => 'unit',
+                    'taxAmount' => 200,
+                    'detailTax' => array(
+                        'taxIncludedInTotal' => true,
+                        'taxAmount' => 200
+                    ),
+                    'itemCategory' => 'Aparel',
+                    'itemSubCategory' => 'Clothing',
+                    'productId' => '1001',
+                    'productName' => 'N1',
+                ),
+                'lineItemData1' => array(
+                    'itemSequenceNumber' => '2',
+                    'itemDescription' => 'product 2',
+                    'productCode' => '456',
+                    'quantity' => 1,
+                    'unitOfMeasure' => 'unit',
+                    'taxAmount' => 300,
+                    'detailTax' => array(
+                        'taxIncludedInTotal' => true,
+                        'taxAmount' => 300
+                    )
+                ),
+                'salesTax' => '500',
+                'taxExempt' => false,
+                'fulfilmentMethodType' => 'STANDARD_SHIPPING'
+            ),
+        );
+
+        $initialize = new CnpOnlineRequest();
+        $authorizationResponse = $initialize->authorizationRequest($hash_in);
+        $response = XmlParser::getNode($authorizationResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($authorizationResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/AuthFunctionalTest.php
+++ b/cnp/sdk/Test/functional/AuthFunctionalTest.php
@@ -1397,4 +1397,36 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_auth()
+    {
+        $hash_in = array('id' => 'id',
+            'card' => array('type' => 'MC',
+                'number' => '5112000900000005',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'),
+            'id' => '1211',
+            'orderId' => '22@33',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'businessIndicator'=>'agentCashOut',
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Smith',
+                'receiverState' => 'AZ',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '1234567890',
+                'accountFundingTransactionType' => 'walletTransfer',
+                'receiverAccountNumberType' => 'cardAccount'
+            ),
+            'amount' => '1512',
+            'oltpEncryptionPayload' => true
+            );
+
+        $initialize = new CnpOnlineRequest();
+        $authorizationResponse = $initialize->authorizationRequest($hash_in);
+        $response = XmlParser::getNode($authorizationResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($authorizationResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/BNPLAuthorizationRequestTest.php
+++ b/cnp/sdk/Test/functional/BNPLAuthorizationRequestTest.php
@@ -97,4 +97,35 @@ class BNPLAuthorizationRequestTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function test_encrypted_BNPL_Authorization_Request()
+    {
+        $hash_in = array(
+            'id' => '1211',
+            'orderId' => '2111',
+            'reportGroup' => 'Planets',
+            'amount' => '1000',
+            'provider' => 'AFFIRM',
+            'postCheckoutRedirectUrl' => 'www.abc.com',
+            'customerInfo' => array(
+                'accountUsername' => 'username123',
+                'userAccountNumber' => '7647326235897',
+                'userAccountEmail' => 'dummtemail@abc.com',
+                'membershipId' => '23874682304',
+                'membershipPhone' => '16818807607551094758',
+                'membershipEmail' => 'email@abc.com',
+                'membershipName' => 'member123',
+                'accountCreatedDate' => '2050-07-17',
+                'userAccountPhone' => '1392345678',
+            ),
+            'oltpEncryptionPayload' => true
+        );
+        $initialize = new CnpOnlineRequest();
+        $BNPLAuthorizationResponse = $initialize->BNPLAuthorizationRequest($hash_in);
+        $response = XmlParser::getNode($BNPLAuthorizationResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($BNPLAuthorizationResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+
+    }
+
 }

--- a/cnp/sdk/Test/functional/BatchRequestFunctionalTest.php
+++ b/cnp/sdk/Test/functional/BatchRequestFunctionalTest.php
@@ -3390,6 +3390,140 @@ class BatchRequestFunctionalTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function test_batch_12_40()
+    {
+        if(strtolower($this->preliveStatus) == 'down'){
+            $this->markTestSkipped('Prelive is not available');
+        }
+
+        $request = new CnpRequest();
+
+        $batch = new BatchRequest();
+        $hash_in = array('id' => '123',
+            'card' => array('type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'),
+            'cardholderAuthentication' => array(
+                'authenticationProtocolVersion' => 9),
+            'orderId' => '22@33',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'amount' => '1000',
+            'orderChannel' => 'SCAN_AND_GO',
+            'businessIndicator'=>'agentCashOut',
+            'passengerTransportData' =>array(
+                'passengerName' =>'Mrs. Abc',
+                'ticketNumber' =>'ATL456789010000' ,
+                'issuingCarrier' =>'AMTK',
+                'carrierName' =>'AMTK',
+                'restrictedTicketIndicator' =>'99999',
+                'numberOfAdults' =>'3',
+                'numberOfChildren' =>'0',
+                'customerCode' =>'Railway',
+                'arrivalDate' =>'2023-09-20',
+                'issueDate' =>'2023-09-10',
+                'travelAgencyCode' =>'12345678',
+                'travelAgencyName' =>'Travel R Us23456789054321',
+                'computerizedReservationSystem' =>'STRT',
+                'creditReasonIndicator' =>'P',
+                'ticketChangeIndicator' =>'C',
+                'ticketIssuerAddress' =>'99 Second St',
+                'exchangeTicketNumber' =>'123456789012346',
+                'exchangeAmount' =>'500006',
+                'exchangeFeeAmount' =>'5006',
+                'tripLegData' =>array(
+                    'tripLegNumber' =>'12' ,
+                    'serviceClass' =>'First',
+                    'departureDate' =>'2023-09-20',
+                    'originCity' =>'BOS')
+            ),
+            'fraudCheckAction' => 'APPROVED_SKIP_FRAUD_CHECK',
+            'typeOfDigitalCurrency' => 'BCoin',
+            'conversionAffiliateId' => 'DC12345'
+        );
+        $batch->addAuth($hash_in);
+
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000001',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'
+            ),
+            'id' => '1211',
+            'orderId' => '2111',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'orderChannel' => 'SCAN_AND_GO',
+            'fraudCheckAction' => 'APPROVED_SKIP_FRAUD_CHECK',
+            'amount' => '123',
+            'businessIndicator'=>'businessToBusinessTransfer',
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Jon',
+                'receiverState' => 'CA',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '4356872257i',
+                'accountFundingTransactionType' => 'businessDisbursement',
+                'receiverAccountNumberType' => 'RTNAndBAN'
+            ),
+            'overridePolicy' => 'merchantPolicyToDecline',
+            'fsErrorCode' => 'error123',
+            'merchantAccountStatus' => 'activeAccount',
+            'productEnrolled' => 'GUARPAY2',
+            'decisionPurpose' => 'INFORMATION_ONLY',
+            'fraudSwitchIndicator' => 'PRE',
+            'typeOfDigitalCurrency' => 'DCoin',
+            'conversionAffiliateId' => 'DC15345'
+        );
+        $batch->addSale($hash_in);
+
+        $hash_in = array(
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'
+            ),
+            'id' => '1211',
+            'orderId' => '2111',
+            'cnpTxnId' => '12345678000',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'amount' => '123'
+        );
+        $batch->addCapture($hash_in);
+
+        $hash_in = array('id' => 'id',
+            'reportGroup' => 'Planets',
+            'rtp' => 'true',
+            'fundingSubmerchantId' => '2111',
+            'submerchantName' => '001',
+            'fundsTransferId' => '12345678',
+            'amount' => '13',
+            'accountInfo' => array(
+                'accType' => 'Checking',
+                'accNum' => '12345657890',
+                'routingNum' => '123456789',
+                'checkNum' => '123455'
+            ),
+            'partialCapture' => array(
+                'partialCaptureSequenceNumber' => '3',
+                'partialCaptureTotalCount' => '5'
+            )
+        );
+        $batch->addSubmerchantCredit($hash_in);
+
+        $request->addBatchRequest($batch);
+
+        $resp = new CnpResponseProcessor($request->sendToCnp());
+
+        $message = $resp->getXmlReader()->getAttribute("message");
+        $response = $resp->getXmlReader()->getAttribute("response");
+        $this->assertEquals("Valid Format", $message);
+        $this->assertEquals(0, $response);
+
+    }
+
     public function tearDown()
     {
         $files = glob($this->direct . '/*'); // get all file names

--- a/cnp/sdk/Test/functional/CaptureFunctionalTest.php
+++ b/cnp/sdk/Test/functional/CaptureFunctionalTest.php
@@ -281,4 +281,19 @@ class CaptureFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_capture()
+    {
+        $hash_in = array('id' => 'id',
+            'cnpTxnId' => '1234567891234567891',
+            'amount' => '123',
+            'oltpEncryptionPayload' => true);
+
+        $initialize = new CnpOnlineRequest();
+        $captureResponse = $initialize->captureRequest($hash_in);
+        $message = XmlParser::getAttribute($captureResponse, 'cnpOnlineResponse', 'response');
+        $this->assertEquals('0', $message);
+        $location = XmlParser::getNode($captureResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/CaptureFunctionalTest.php
+++ b/cnp/sdk/Test/functional/CaptureFunctionalTest.php
@@ -257,4 +257,28 @@ class CaptureFunctionalTest extends \PHPUnit_Framework_TestCase
         $location = XmlParser::getNode($captureResponse, 'location');
         $this->assertEquals('sandbox', $location);
     }
+
+    public function test_capture_digitalCurrency()
+    {
+        $hash_in = array('id' => 'id',
+            'cnpTxnId' => '1234567891234567891',
+            'amount' => '123', 'enhancedData' => array(
+                'customerReference' => 'Litle',
+                'salesTax' => '50',
+                'deliveryType' => 'TBD'),
+            'payPalOrderComplete' => 'true',
+            'partialCapture' => array(
+                'partialCaptureSequenceNumber' => '1',
+                'partialCaptureTotalCount' => '7'
+            )
+            );
+
+        $initialize = new CnpOnlineRequest();
+        $captureResponse = $initialize->captureRequest($hash_in);
+        $message = XmlParser::getAttribute($captureResponse, 'cnpOnlineResponse', 'response');
+        $this->assertEquals('0', $message);
+        $location = XmlParser::getNode($captureResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/CaptureGivenAuthFunctionalTest.php
+++ b/cnp/sdk/Test/functional/CaptureGivenAuthFunctionalTest.php
@@ -654,4 +654,39 @@ class CaptureGivenAuthFunctionalTest extends \PHPUnit_Framework_TestCase
         $location = XmlParser::getNode($authorizationResponse, 'location');
         $this->assertEquals('sandbox', $location);
     }
+
+    public function test_simple_captureGivenAuth_with_DigitalCurrency()
+    {
+        $hash_in = array('id' => 'id',
+            'orderId' => '12344',
+            'amount' => '106',
+            'authInformation' => array(
+                'authDate' => '2002-10-09', 'authCode' => '543216',
+                'authAmount' => '12345'),
+            'orderSource' => 'ecommerce',
+            'businessIndicator'=>'agentCashOut',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'),
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Harry',
+                'receiverState' => 'NU',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '1234567890',
+                'accountFundingTransactionType' => 'personToPerson',
+                'receiverAccountNumberType' => 'email'
+            ),
+            'typeOfDigitalCurrency' => '1',
+            'conversionAffiliateId' => 'Test',
+        );
+
+        $initialize = new CnpOnlineRequest();
+        $captureGivenAuthResponse = $initialize->captureGivenAuthRequest($hash_in);
+        $message = XmlParser::getNode($captureGivenAuthResponse, 'message');
+        $this->assertEquals('Approved', $message);
+        $location = XmlParser::getNode($captureGivenAuthResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/CaptureGivenAuthFunctionalTest.php
+++ b/cnp/sdk/Test/functional/CaptureGivenAuthFunctionalTest.php
@@ -689,4 +689,36 @@ class CaptureGivenAuthFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_captureGivenAuth()
+    {
+        $hash_in = array('id' => 'id',
+            'orderId' => '12344',
+            'amount' => '106',
+            'authInformation' => array(
+                'authDate' => '2002-10-09', 'authCode' => '543216',
+                'authAmount' => '12345'),
+            'orderSource' => 'ecommerce',
+            'businessIndicator'=>'agentCashOut',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'),
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Harry',
+                'receiverState' => 'NU',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '1234567890',
+                'accountFundingTransactionType' => 'personToPerson',
+                'receiverAccountNumberType' => 'email'
+            ),
+            'oltpEncryptionPayload' => true);
+
+        $initialize = new CnpOnlineRequest();
+        $captureGivenAuthResponse = $initialize->captureGivenAuthRequest($hash_in);
+        $message = XmlParser::getNode($captureGivenAuthResponse, 'message');
+        $this->assertEquals('Approved', $message);
+        $location = XmlParser::getNode($captureGivenAuthResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/CreditFunctionalTest.php
+++ b/cnp/sdk/Test/functional/CreditFunctionalTest.php
@@ -403,4 +403,39 @@ class CreditFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_credit()
+    {
+        $hash_in = array(
+            'card' => array('type' => 'VI', 'id' => 'id',
+                'number' => '4100000000000000',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'),
+            'id' => '1211',
+            'orderId' => '2111',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'amount' => '123',
+            'businessIndicator'=>'rapidMerchantSettlement',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'),
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Jon',
+                'receiverState' => 'AZ',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '4356872257i',
+                'accountFundingTransactionType' => 'paymentOfOwnCreditCardBill',
+                'receiverAccountNumberType' => 'cardAccount'
+            ),
+        'oltpEncryptionPayload' => true);
+
+        $initialize = new CnpOnlineRequest();
+        $creditResponse = $initialize->creditRequest($hash_in);
+        $response = XmlParser::getNode($creditResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($creditResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/EcheckSaleFunctionalTest.php
+++ b/cnp/sdk/Test/functional/EcheckSaleFunctionalTest.php
@@ -180,4 +180,23 @@ class EcheckSaleFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_echeckSale_with_echeck()
+    {
+        $hash_in = array('id' => 'id',
+            'amount' => '123456',
+            'verify' => 'true',
+            'orderId' => '12345',
+            'orderSource' => 'ecommerce',
+            'echeck' => array('accType' => 'Checking', 'accNum' => '12345657890', 'routingNum' => '123456789', 'checkNum' => '123455','echeckCustomerId' => 'customer_v12.34','accountId' => 'account'),
+            'billToAddress' => array('name' => 'Bob', 'city' => 'lowell', 'state' => 'MA', 'email' => 'vantiv.com'),
+            'oltpEncryptionPayload' => true);
+
+        $initialize = new CnpOnlineRequest();
+        $echeckSaleResponse = $initialize->echeckSaleRequest($hash_in);
+        $response = XmlParser::getNode($echeckSaleResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($echeckSaleResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/EncryptionRequestFunctionalTest.php
+++ b/cnp/sdk/Test/functional/EncryptionRequestFunctionalTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace cnp\sdk\Test\functional;
+namespace cnp\sdk\Test\functional;
+
+use cnp\sdk\CnpOnlineRequest;
+use cnp\sdk\CommManager;
+use cnp\sdk\XmlParser;
+
+
+class EncryptionRequestFunctionalTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        CommManager::reset();
+    }
+
+    public function test_simple_encryption_key_Request()
+    {
+        $hash_in = array('encryptionKeyRequest' => 'CURRENT');
+
+        $initialize = new CnpOnlineRequest();
+        $encryptionKeyResponse = $initialize->encryptionKeyRequest($hash_in);
+        $response = XmlParser::getNode($encryptionKeyResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($encryptionKeyResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+
+    }
+
+    public function test_simple_payload_Request()
+    {
+        $hash_in = array('encryptionKeySequence' => '12',
+            'payload' => '12345678912345'
+        );
+
+
+        $initialize = new CnpOnlineRequest();
+        $encryptionPayloadResponse = $initialize->encryptedPayload($hash_in);
+        $response = XmlParser::getNode($encryptionPayloadResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($encryptionPayloadResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+
+    }
+}

--- a/cnp/sdk/Test/functional/EncryptionRequestFunctionalTest.php
+++ b/cnp/sdk/Test/functional/EncryptionRequestFunctionalTest.php
@@ -5,6 +5,7 @@ namespace cnp\sdk\Test\functional;
 
 use cnp\sdk\CnpOnlineRequest;
 use cnp\sdk\CommManager;
+use cnp\sdk\exceptions\cnpSDKException;
 use cnp\sdk\XmlParser;
 
 
@@ -15,32 +16,17 @@ class EncryptionRequestFunctionalTest extends \PHPUnit_Framework_TestCase
         CommManager::reset();
     }
 
+    /**
+     * @throws cnpSDKException
+     */
     public function test_simple_encryption_key_Request()
     {
         $hash_in = array('encryptionKeyRequest' => 'CURRENT');
 
         $initialize = new CnpOnlineRequest();
         $encryptionKeyResponse = $initialize->encryptionKeyRequest($hash_in);
-        $response = XmlParser::getNode($encryptionKeyResponse, 'response');
-        $this->assertEquals('000', $response);
-        $location = XmlParser::getNode($encryptionKeyResponse, 'location');
-        $this->assertEquals('sandbox', $location);
-
-    }
-
-    public function test_simple_payload_Request()
-    {
-        $hash_in = array('encryptionKeySequence' => '12',
-            'payload' => '12345678912345'
-        );
-
-
-        $initialize = new CnpOnlineRequest();
-        $encryptionPayloadResponse = $initialize->encryptedPayload($hash_in);
-        $response = XmlParser::getNode($encryptionPayloadResponse, 'response');
-        $this->assertEquals('000', $response);
-        $location = XmlParser::getNode($encryptionPayloadResponse, 'location');
-        $this->assertEquals('sandbox', $location);
+        $response = XmlParser::getNode($encryptionKeyResponse, 'encryptionKeySequence');
+        $this->assertEquals('10000', $response);
 
     }
 }

--- a/cnp/sdk/Test/functional/FastAccessFundingFunctionalTest.php
+++ b/cnp/sdk/Test/functional/FastAccessFundingFunctionalTest.php
@@ -91,4 +91,26 @@ class FastAccessFundingFunctionalTest extends \PHPUnit_Framework_TestCase
         $location = XmlParser::getNode($fastAccessFundingResponse, 'location');
         $this->assertEquals('sandbox', $location);
     }
+
+    public function test_encrypted_fastAccessFunding()
+    {
+        $hash_in = array('id' => 'id',
+            'fundingSubmerchantId' => '2111',
+            'submerchantName' => '001',
+            'fundsTransferId' => '1234567891111111',
+            'amount' => '13',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'
+            ),
+            'oltpEncryptionPayload' => true
+        );
+        $initialize = new CnpOnlineRequest();
+        $fastAccessFundingResponse = $initialize->fastAccessFunding($hash_in);
+        $response = XmlParser::getNode($fastAccessFundingResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($fastAccessFundingResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
 }

--- a/cnp/sdk/Test/functional/FinicityUrlRequestTest.php
+++ b/cnp/sdk/Test/functional/FinicityUrlRequestTest.php
@@ -32,4 +32,23 @@ class finicityUrlRequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
 
     }
+
+    public function test_encrypted_finicity_Url_Request()
+    {
+        $hash_in = array(
+            'id' => '1211',
+            'firstName' => 'abc',
+            'lastName' => 'xyz',
+            'phoneNumber' => '123456789',
+            'email' => 'abc@gmail.com',
+            'oltpEncryptionPayload' => true
+        );
+        $initialize = new CnpOnlineRequest();
+        $finicityUrlResponse = $initialize->finicityUrlRequest($hash_in);
+        $response = XmlParser::getNode($finicityUrlResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($finicityUrlResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+
+    }
 }

--- a/cnp/sdk/Test/functional/RefundTransactionReversalFunctionalTest.php
+++ b/cnp/sdk/Test/functional/RefundTransactionReversalFunctionalTest.php
@@ -128,4 +128,52 @@ class RefundTransactionReversalFunctionalTest extends \PHPUnit_Framework_TestCas
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_refundTransactionReversal()
+    {
+        $hash_in = array(
+            'id' => 'id',
+            'cnpTxnId' => '12345678000',
+            'amount' => '123',
+            'pin' => '1234',
+            'surchargeAmount' => '4321',
+            'enhancedData' => array(
+                'customerReference' => 'cust ref sale1',
+                'salesTax' => '1000',
+                'discountAmount' => '0',
+                'shippingAmount' => '0',
+                'dutyAmount' => '0',
+                'lineItemData' => array(
+                    'itemSequenceNumber' => '1',
+                    'itemDescription' => 'Clothes',
+                    'productCode' => 'TB123',
+                    'quantity' => '1',
+                    'unitOfMeasure' => 'EACH',
+                    'lineItemTotal' => '9900',
+                    'lineItemTotalWithTax' => '10000',
+                    'itemDiscountAmount' => '0',
+                    'commodityCode' => '301',
+                    'unitCost' => '31.02',
+                    'itemCategory' => 'Aparel',
+                    'itemSubCategory' => 'Clothing',
+                ),
+                'discountCode' => 'OneTimeDiscount11',
+                'discountPercent' => '11',
+                'fulfilmentMethodType' => 'EXPEDITED_SHIPPING',
+            ),
+            'oltpEncryptionPayload' => true
+        );
+
+        $initilaize = new CnpOnlineRequest();
+        $refundTransactionReversalResponse = $initilaize->refundTransactionReversal($hash_in);
+
+        $response = XmlParser::getNode($refundTransactionReversalResponse, 'response');
+        $this->assertEquals('000', $response);
+
+        $response = XmlParser::getNode($refundTransactionReversalResponse, 'message');
+        $this->assertEquals('Approved', $response);
+
+        $location = XmlParser::getNode($refundTransactionReversalResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/SaleFunctionalTest.php
+++ b/cnp/sdk/Test/functional/SaleFunctionalTest.php
@@ -1514,5 +1514,41 @@ class SaleFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_sale()
+    {
+        $hash_in = array(
+            'card' => array('type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'),
+            'id' => '1211',
+            'orderId' => '2111',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'orderChannel' => 'SCAN_AND_GO',
+            'fraudCheckAction' => 'APPROVED_SKIP_FRAUD_CHECK',
+            'amount' => '123',
+            'businessIndicator'=>'businessToBusinessTransfer',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'),
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Jon',
+                'receiverState' => 'CA',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '4356872257i',
+                'accountFundingTransactionType' => 'businessDisbursement',
+                'receiverAccountNumberType' => 'RTNAndBAN'),
+            'oltpEncryptionPayload' => true);
+
+        $initialize = new CnpOnlineRequest();
+        $saleResponse = $initialize->saleRequest($hash_in);
+        $response = XmlParser::getNode($saleResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($saleResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 
 }

--- a/cnp/sdk/Test/functional/SaleFunctionalTest.php
+++ b/cnp/sdk/Test/functional/SaleFunctionalTest.php
@@ -1474,5 +1474,45 @@ class SaleFunctionalTest extends \PHPUnit_Framework_TestCase
         $message = XmlParser::getNode($authorizationResponse, 'message');
         $this->assertEquals('Approved', $message);
     }
-    
+
+    public function test_simple_sale_with_digitalCurrency()
+    {
+        $hash_in = array(
+            'card' => array('type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'),
+            'id' => '1211',
+            'orderId' => '2111',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'orderChannel' => 'SCAN_AND_GO',
+            'fraudCheckAction' => 'APPROVED_SKIP_FRAUD_CHECK',
+            'amount' => '123',
+            'businessIndicator'=>'businessToBusinessTransfer',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'),
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Jon',
+                'receiverState' => 'CA',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '4356872257i',
+                'accountFundingTransactionType' => 'businessDisbursement',
+                'receiverAccountNumberType' => 'RTNAndBAN'
+            ),
+            'typeOfDigitalCurrency' => '1',
+            'conversionAffiliateId' => 'Test',
+        );
+
+        $initialize = new CnpOnlineRequest();
+        $saleResponse = $initialize->saleRequest($hash_in);
+        $response = XmlParser::getNode($saleResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($saleResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
+
 }

--- a/cnp/sdk/Test/functional/TokenFunctionalTest.php
+++ b/cnp/sdk/Test/functional/TokenFunctionalTest.php
@@ -145,4 +145,22 @@ class TokenFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_encrypted_token()
+    {
+        $hash_in = array('id' => '1211',
+            'merchantId' => '101',
+            'version' => '8.8',
+            'reportGroup' => 'Planets',
+            'orderId' => '12344',
+            'accountNumber' => '1233456789103801',
+            'oltpEncryptionPayload' => true);
+
+        $initialize = new CnpOnlineRequest();
+        $registerTokenResponse = $initialize->registerTokenRequest($hash_in);
+        $message = XmlParser::getAttribute($registerTokenResponse, 'cnpOnlineResponse', 'message');
+        $this->assertEquals('Valid Format', $message);
+        $location = XmlParser::getNode($registerTokenResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/unit/AuthUnitTest.php
+++ b/cnp/sdk/Test/unit/AuthUnitTest.php
@@ -664,4 +664,54 @@ class AuthUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->authorizationRequest($hash_in);
     }
 
+    public function test_simple_auth_with_DigitalCurrency()
+    {
+        $hash_in = array('id' => 'id',
+            'card' => array('type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'),
+            'orderId' => '22833',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'amount' => '1000',
+            'orderChannel' => 'SCAN_AND_GO',
+            'enhancedData' => array(
+                'detailTax0' => array(
+                    'taxAmount' => '200',
+                    'taxRate' => '0.06',
+                    'taxIncludedInTotal' => true
+                ),
+                'detailTax1' => array(
+                    'taxAmount' => '300',
+                    'taxRate' => '0.10',
+                    'taxIncludedInTotal' => true
+                ),
+                'fulfilmentMethodType' => 'STANDARD_SHIPPING',
+            ),
+
+            'accountFundingTransactionData' => array(
+                'receiverFirstName' => 'abc',
+                'receiverLastName' => 'xyz',
+                'receiverState' => 'AK',
+                'receiverCountry' => 'AD',
+                'receiverAccountNumberType' => 'BANAndBIC',
+                'receiverAccountNumber' => '12345',
+                'accountFundingTransactionType' => 'accountToAccount'
+            ),
+            'typeOfDigitalCurrency' => '1',
+            'conversionAffiliateId' => 'Test',
+        );
+
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock	->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<fulfilmentMethodType>STANDARD_SHIPPING.*<accountFundingTransactionData>.*<receiverFirstName>abc.*<receiverLastName>xyz.*<receiverState>AK.*<receiverCountry>AD.*<receiverAccountNumberType>BANAndBIC.*<receiverAccountNumber>123.*<accountFundingTransactionType>accountToAccount.*<typeOfDigitalCurrency>1.*<conversionAffiliateId>Test.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->authorizationRequest($hash_in);
+    }
+
+
 }

--- a/cnp/sdk/Test/unit/AuthUnitTest.php
+++ b/cnp/sdk/Test/unit/AuthUnitTest.php
@@ -713,5 +713,54 @@ class AuthUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->authorizationRequest($hash_in);
     }
 
+    public function test_encrypted_auth_with_lineItemData0()
+    {
+        $hash_in = array('id' => 'id',
+            'card' => array('type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1213',
+                'cardValidationNum' => '1213'),
+            'id' => '1211',
+            'orderId' => '22@33',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'amount' => '0',
+            'enhancedData' => array(
+                'detailTax0' => array(
+                    'taxAmount' => '200',
+                    'taxRate' => '0.06',
+                    'taxIncludedInTotal' => true
+                ),
+                'detailTax1' => array(
+                    'taxAmount' => '300',
+                    'taxRate' => '0.10',
+                    'taxIncludedInTotal' => true
+                ),'lineItemData0' => array(
+                    'itemSequenceNumber' => '1',
+                    'itemDescription' => 'product 1',
+                    'productCode' => '123',
+                    'quantity' => 3,
+                    'unitOfMeasure' => 'unit',
+                    'taxAmount' => 200,
+                    'detailTax' => array(
+                        'taxIncludedInTotal' => true,
+                        'taxAmount' => 200
+                    ),
+                    'itemCategory' => 'Aparel',
+                    'itemSubCategory' => 'Clothing',
+                    'productId' => '1001',
+                    'productName' => 'N1',
+                )),
+            'oltpEncryptionPayload' => true);
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock	->expects($this->once())
+            ->method('request')   #.*<cnpOnlineRequest.*<encryptedPayload.*</encryptedPayload>.*
+            ->with($this->matchesRegularExpression('/.*<encryptedPayload.*<encryptionKeySequence>.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->authorizationRequest($hash_in);
+    }
+
 
 }

--- a/cnp/sdk/Test/unit/CaptureGivenAuthUnitTest.php
+++ b/cnp/sdk/Test/unit/CaptureGivenAuthUnitTest.php
@@ -651,4 +651,41 @@ class CaptureGivenAuthUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->newXML = $mock;
         $cnpTest->captureGivenAuthRequest($hash_in);
     }
+
+    public function test_capture_given_auth_with_digitalCurrency()
+    {
+        $hash_in = array('id' => 'id',
+            'orderId' => '12344',
+            'amount' => '106',
+            'authInformation' => array(
+                'authDate' => '2002-10-09', 'authCode' => '543216',
+                'authAmount' => '12345'),
+            'orderSource' => 'ecommerce',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4100000000000000',
+                'expDate' => '1210'),
+            'businessIndicator' => 'consumerBillPayment',
+            'accountFundingTransactionData' => array(
+                'receiverFirstName' => 'abc',
+                'receiverLastName' => 'xyz',
+                'receiverState' => 'NY',
+                'receiverCountry' => 'US',
+                'receiverAccountNumberType' => 'email',
+                'receiverAccountNumber' => '12345',
+                'accountFundingTransactionType' => 'topUp'
+            ),
+            'typeOfDigitalCurrency' => '1',
+            'conversionAffiliateId' => 'Test',
+        );
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock	->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<accountFundingTransactionData>.*<receiverFirstName>abc.*<receiverLastName>xyz.*<receiverState>NY.*<receiverCountry>US.*<receiverAccountNumberType>email.*<receiverAccountNumber>12345.*<accountFundingTransactionType>topUp.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->captureGivenAuthRequest($hash_in);
+    }
+
 }

--- a/cnp/sdk/Test/unit/CaptureUnitTest.php
+++ b/cnp/sdk/Test/unit/CaptureUnitTest.php
@@ -263,4 +263,21 @@ class CaptureUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->newXML = $mock;
         $cnpTest->captureRequest($hash_in);
     }
+
+    public function test_encrypted_capture()
+    {
+        $hash_in = array('cnpTxnId'=> '12312312',
+            'id' => 'id',
+            'merchantSdk'=>'PHP;10.1.0',
+            'amount'=>'123',
+            'oltpEncryptionPayload' => true);
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<encryptedPayload.*<encryptionKeySequence>.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->captureRequest($hash_in);
+    }
 }

--- a/cnp/sdk/Test/unit/CreditUnitTest.php
+++ b/cnp/sdk/Test/unit/CreditUnitTest.php
@@ -591,4 +591,31 @@ class CreditUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->creditRequest($hash_in);;
     }
 
+    public function test_encrypted_credit()
+    {
+
+        $hash_in = array(
+            'reportGroup'=>'Planets',
+            'orderId'=>'12344',
+            'id' => 'id',
+            'amount'=>'106',
+            'orderSource'=>'ecommerce',
+            'merchantCategoryCode' => '3535',
+            'card'=>array(
+                'type'=>'VI',
+                'number' =>'4100000000000001',
+                'expDate' =>'1210'
+            ),
+            'oltpEncryptionPayload' => true);
+
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<encryptedPayload.*<encryptionKeySequence>.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->creditRequest($hash_in);
+    }
+
 }

--- a/cnp/sdk/Test/unit/SaleUnitTest.php
+++ b/cnp/sdk/Test/unit/SaleUnitTest.php
@@ -1298,4 +1298,67 @@ class SaleUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->newXML = $mock;
         $cnpTest->saleRequest($hash_in);
     }
+    public function test_sale_with_digitalCurrency()
+    {
+        $hash_in = array(
+            'id' => 'id',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '1001',
+            'orderSource' => 'telephone',
+            'customerInfo' => array(
+                'accountUsername' => 'username123',
+                'userAccountNumber' => '7647326235897',
+                'userAccountEmail' => 'dummtemail@abc.com',
+                'membershipId' => '23874682304',
+                'membershipPhone' => '16818807607551094758',
+                'membershipEmail' => 'email@abc.com',
+                'membershipName' => 'member123',
+                'accountCreatedDate' => '2050-07-17',
+                'userAccountPhone' => '1392345678',
+            ),
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'orderChannel' => 'SMART_TV',
+            'enhancedData' => array(
+                'detailTax0' => array(
+                    'taxAmount' => '200',
+                    'taxRate' => '0.06',
+                    'taxIncludedInTotal' => true
+                ),
+                'detailTax1' => array(
+                    'taxAmount' => '300',
+                    'taxRate' => '0.10',
+                    'taxIncludedInTotal' => true
+                ),
+                'fulfilmentMethodType' => 'EXPEDITED_SHIPPING',
+            ),
+            'accountFundingTransactionData' => array(
+                'receiverFirstName' => 'abc',
+                'receiverLastName' => 'xyz',
+                'receiverState' => 'AK',
+                'receiverCountry' => 'AD',
+                'receiverAccountNumberType' => 'cardAccount',
+                'receiverAccountNumber' => '12345',
+                'accountFundingTransactionType' => 'bankInitiated'
+            ),
+            'fraudCheckAction' => 'DECLINED_NEED_FRAUD_CHECK',
+            'typeOfDigitalCurrency' => '1',
+            'conversionAffiliateId' => 'Test',
+
+        );
+
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock	->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<fulfilmentMethodType>EXPEDITED_SHIPPING.*<accountFundingTransactionData>.*<receiverFirstName>abc.*<receiverLastName>xyz.*<receiverState>AK.*<receiverCountry>AD.*<receiverAccountNumberType>cardAccount.*<receiverAccountNumber>12345.*<accountFundingTransactionType>bankInitiated.*<fraudCheckAction>DECLINED_NEED_FRAUD_CHECK.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->saleRequest($hash_in);
+    }
+
 }

--- a/cnp/sdk/Test/unit/SaleUnitTest.php
+++ b/cnp/sdk/Test/unit/SaleUnitTest.php
@@ -1361,4 +1361,26 @@ class SaleUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->saleRequest($hash_in);
     }
 
+    public function test_encrypted_sale()
+    {
+        $hash_in = array(
+            'card'=>array('type'=>'VI',
+                'number'=>'4100000000000001',
+                'expDate'=>'1213',
+                'cardValidationNum' => '1213'),
+            'id'=>'654',
+            'orderId'=> '2111',
+            'orderSource'=>'ecommerce',
+            'amount'=>'123',
+            'oltpEncryptionPayload' => true);
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<encryptedPayload.*<encryptionKeySequence>.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->saleRequest($hash_in);
+    }
+
 }

--- a/cnp/sdk/XmlFields.php
+++ b/cnp/sdk/XmlFields.php
@@ -1037,6 +1037,19 @@ class XmlFields
         }
     }
 
+    public static function partialCapture($hash_in)
+    {
+        if (isset($hash_in)) {
+            $hash_out = array(
+                "partialCaptureSequenceNumber"=>XmlFields::returnArrayValue($hash_in, "partialCaptureSequenceNumber", 100),
+                "partialCaptureTotalCount"=>XmlFields::returnArrayValue($hash_in, "partialCaptureTotalCount", 100),
+             );
+
+            return $hash_out;
+        }
+    }
+
+
     public static function sellerTagsType($hash_in)
     {
         if (isset($hash_in)) {
@@ -1120,5 +1133,7 @@ class XmlFields
             return $hash_out;
         }
     }
+
+
 
 }

--- a/cnp/sdk/schema/SchemaCombined_v12.40.xsd
+++ b/cnp/sdk/schema/SchemaCombined_v12.40.xsd
@@ -275,6 +275,7 @@
             <xs:enumeration value="X" />
             <xs:enumeration value="FIFA" />
             <xs:enumeration value="FIVC" />
+            <xs:enumeration value="FIVD" />
             <xs:enumeration value="FISC" />
             <xs:enumeration value="FISD" />
             <xs:enumeration value="FIPC" />
@@ -362,6 +363,8 @@
     <xs:simpleType name="transactionAmountType">
         <xs:restriction base="xs:integer">
             <xs:totalDigits value="12" />
+            <xs:minInclusive value="-999999999999"/>
+            <xs:maxInclusive value="999999999999"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -1391,6 +1394,38 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="encryptionKeyRequestEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CURRENT"/>
+            <xs:enumeration value="PREVIOUS"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="encryptionKeySequenceType">
+        <xs:restriction base="xs:long">
+            <xs:totalDigits value="19"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="encryptionKeyType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="15000"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="payloadType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="15000" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="partialCaptureCount">
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1" />
+            <xs:maxInclusive value="99" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <!--cnpRecurring-->
 
     <!--    <xs:include schemaLocation="cnpCommon_v12.24.xsd"/>-->
@@ -1653,9 +1688,6 @@
 
     <!--cnpTransaction-->
 
-    <!--    <xs:include schemaLocation="cnpCommon_v12.24.xsd"/>-->
-    <!--    <xs:include schemaLocation="cnpRecurring_v12.24.xsd"/>-->
-
     <xs:element name="transaction" type="xp:transactionType" abstract="true"/>
 
     <xs:complexType name="transactionType">
@@ -1671,6 +1703,15 @@
         <xs:complexContent>
             <xs:extension base="xp:transactionType">
                 <xs:attribute name="reportGroup" type="xp:reportGroupType" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="transactionTypeWithReportGroupAndRtp">
+        <xs:complexContent>
+            <xs:extension base="xp:transactionType">
+                <xs:attribute name="reportGroup" type="xp:reportGroupType" use="required"/>
+                <xs:attribute name="rtp" type="xs:boolean" use="optional" />
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -1848,6 +1889,9 @@
                             <xs:element name="authIndicator" type="xp:authIndicatorEnum" minOccurs="0"/>
                             <xs:element ref="xp:accountFundingTransactionData" minOccurs="0"/>
                             <xs:element name="fraudCheckAction" type="xp:fraudCheckActionEnum" minOccurs="0"/>
+                            <!--    US1938960-77433-->
+                            <xs:element name="typeOfDigitalCurrency" type="xp:string5Type" minOccurs="0"/>
+                            <xs:element name="conversionAffiliateId" type="xp:string15Type" minOccurs="0"/>
                         </xs:sequence>
                     </xs:choice>
                 </xs:extension>
@@ -1908,6 +1952,7 @@
                         <xs:element name="pin" type="xp:pinType" minOccurs="0"/>
                         <xs:element ref="xp:passengerTransportData" minOccurs="0"/>
                         <xs:element name="foreignRetailerIndicator" type="xp:foreignRetailerIndicatorEnum" minOccurs="0"/>
+                        <xs:element ref="xp:partialCapture" minOccurs="0"/>
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -2006,6 +2051,9 @@
                         <xs:element ref="xp:passengerTransportData" minOccurs="0"/>
                         <xs:element name="foreignRetailerIndicator" type="xp:foreignRetailerIndicatorEnum" minOccurs="0"/>
                         <xs:element ref="xp:accountFundingTransactionData" minOccurs="0"/>
+                        <!--    US1938960-77433-->
+                        <xs:element name="typeOfDigitalCurrency" type="xp:string5Type" minOccurs="0"/>
+                        <xs:element name="conversionAffiliateId" type="xp:string15Type" minOccurs="0"/>
                     </xs:sequence>
                 </xs:extension>
             </xs:complexContent>
@@ -2088,6 +2136,9 @@
                         <xs:element name="foreignRetailerIndicator" type="xp:foreignRetailerIndicatorEnum" minOccurs="0"/>
                         <xs:element ref="xp:accountFundingTransactionData" minOccurs="0"/>
                         <xs:element name="fraudCheckAction" type="xp:fraudCheckActionEnum" minOccurs="0"/>
+                        <!--    US1938960-77433-->
+                        <xs:element name="typeOfDigitalCurrency" type="xp:string5Type" minOccurs="0"/>
+                        <xs:element name="conversionAffiliateId" type="xp:string15Type" minOccurs="0"/>
                     </xs:sequence>
                 </xs:extension>
             </xs:complexContent>
@@ -2565,6 +2616,7 @@
                         <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0"/>
                         <!--If AuthMax is used -->
                         <xs:element ref="xp:authMax" minOccurs="0"/>
+                        <xs:element name="fundingTransactionReferenceNumber" type="xp:string19Type" minOccurs="0"/>
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -3030,6 +3082,7 @@
                         <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0"/>
                         <!--If AuthMax is used -->
                         <xs:element ref="xp:authMax" minOccurs="0"/>
+                        <xs:element name="fundingTransactionReferenceNumber" type="xp:string19Type" minOccurs="0"/>
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -3603,6 +3656,13 @@
         <xs:restriction base="xs:integer">
             <xs:enumeration value="1"/>
             <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="9"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -4163,7 +4223,7 @@
     <xs:element name="payFacCredit" substitutionGroup="xp:transaction">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
+                <xs:extension base="xp:transactionTypeWithReportGroupAndRtp">
                     <xs:choice>
                         <xs:sequence>
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType"/>
@@ -4219,7 +4279,7 @@
     <xs:element name="reserveCredit" substitutionGroup="xp:transaction">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
+                <xs:extension base="xp:transactionTypeWithReportGroupAndRtp">
                     <xs:choice>
                         <xs:sequence>
                             <xs:choice>
@@ -4574,7 +4634,7 @@
     <xs:element name="payoutOrgCredit" substitutionGroup="xp:transaction">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
+                <xs:extension base="xp:transactionTypeWithReportGroupAndRtp">
                     <xs:choice>
                         <xs:sequence>
                             <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType"/>
@@ -4993,6 +5053,15 @@
         </xs:all>
     </xs:complexType>
 
+    <xs:element name="partialCapture">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="partialCaptureSequenceNumber" type="xp:partialCaptureCount" minOccurs="0"/>
+                <xs:element name="partialCaptureTotalCount" type="xp:partialCaptureCount" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
     <!--cnpBatch-->
 
     <!--    <xs:include schemaLocation="cnpTransaction_v12.24.xsd"/>-->
@@ -5326,7 +5395,7 @@
     <xs:element name="submerchantCredit" substitutionGroup="xp:transaction">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
+                <xs:extension base="xp:transactionTypeWithReportGroupAndRtp">
                     <xs:choice>
                         <xs:sequence>
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
@@ -5399,7 +5468,6 @@
         </xs:complexType>
     </xs:element>
 
-
     <!--cnpOnline-->
 
     <!--    <xs:include schemaLocation="cnpTransaction_v12.24.xsd"/>-->
@@ -5410,6 +5478,8 @@
             <xs:choice>
                 <xs:element ref="xp:transaction" />
                 <xs:element ref="xp:recurringTransaction" />
+                <xs:element ref="xp:encryptionKeyRequest"/>
+                <xs:element ref="xp:encryptedPayload" />
             </xs:choice>
         </xs:sequence>
         <xs:attribute name="version" type="xp:versionType" use="required" />
@@ -5433,6 +5503,7 @@
             <xs:choice>
                 <xs:element ref="xp:transactionResponse" minOccurs="0" />
                 <xs:element ref="xp:recurringTransactionResponse" minOccurs="0" />
+                <xs:element ref="xp:encryptionKeyResponse" minOccurs="0"/>
             </xs:choice>
             <xs:attribute name="response" type="xp:responseType" use="required" />
             <xs:attribute name="message" type="xp:messageType" use="required" />
@@ -5707,126 +5778,126 @@
         </xs:complexType>
     </xs:element>
 
-    <!--<xs:element name="vendorCredit" substitutionGroup="xp:transaction">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
-                    <xs:choice>
-                        <xs:sequence>
-                            <xs:choice>
-                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" minOccurs="0" />
-                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" minOccurs="0" />
-                            </xs:choice>
-                            <xs:element name="vendorName" type="xp:string256Type"/>
-                            <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:achTransactionAmountType" />
-                            <xs:element name="accountInfo" type="xp:echeckType" />
-                            <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
-                        </xs:sequence>
-                    </xs:choice>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+    <!--  <xs:element name="vendorCredit" substitutionGroup="xp:transaction">
+          <xs:complexType>
+              <xs:complexContent>
+                  <xs:extension base="xp:transactionTypeWithReportGroup">
+                      <xs:choice>
+                          <xs:sequence>
+                              <xs:choice>
+                                  <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" minOccurs="0" />
+                                  <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" minOccurs="0" />
+                              </xs:choice>
+                              <xs:element name="vendorName" type="xp:string256Type"/>
+                              <xs:element name="fundsTransferId" type="xp:string36Type" />
+                              <xs:element name="amount" type="xp:achTransactionAmountType" />
+                              <xs:element name="accountInfo" type="xp:echeckType" />
+                              <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
+                          </xs:sequence>
+                      </xs:choice>
+                  </xs:extension>
+              </xs:complexContent>
+          </xs:complexType>
+      </xs:element>
 
-    <xs:element name="vendorDebit" substitutionGroup="xp:transaction">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
-                    <xs:choice>
-                        <xs:sequence>
-                            <xs:choice>
-                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" minOccurs="0" />
-                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" minOccurs="0" />
-                            </xs:choice>
-                            <xs:element name="vendorName" type="xp:string256Type"/>
-                            <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:achTransactionAmountType" />
-                            <xs:element name="accountInfo" type="xp:echeckType" />
-                            <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
-                        </xs:sequence>
-                    </xs:choice>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+      <xs:element name="vendorDebit" substitutionGroup="xp:transaction">
+          <xs:complexType>
+              <xs:complexContent>
+                  <xs:extension base="xp:transactionTypeWithReportGroup">
+                      <xs:choice>
+                          <xs:sequence>
+                              <xs:choice>
+                                  <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" minOccurs="0" />
+                                  <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" minOccurs="0" />
+                              </xs:choice>
+                              <xs:element name="vendorName" type="xp:string256Type"/>
+                              <xs:element name="fundsTransferId" type="xp:string36Type" />
+                              <xs:element name="amount" type="xp:achTransactionAmountType" />
+                              <xs:element name="accountInfo" type="xp:echeckType" />
+                              <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
+                          </xs:sequence>
+                      </xs:choice>
+                  </xs:extension>
+              </xs:complexContent>
+          </xs:complexType>
+      </xs:element>
 
 
-    <xs:element name="submerchantCredit" substitutionGroup="xp:transaction">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
-                    <xs:choice>
-                        <xs:sequence>
-                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
-                            <xs:element name="submerchantName" type="xp:string256Type"/>
-                            <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:achTransactionAmountType" />
-                            <xs:element name="accountInfo" type="xp:echeckType" />
-                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
-                        </xs:sequence>
-                    </xs:choice>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+      <xs:element name="submerchantCredit" substitutionGroup="xp:transaction">
+          <xs:complexType>
+              <xs:complexContent>
+                  <xs:extension base="xp:transactionTypeWithReportGroupAndRtp">
+                      <xs:choice>
+                          <xs:sequence>
+                              <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                              <xs:element name="submerchantName" type="xp:string256Type"/>
+                              <xs:element name="fundsTransferId" type="xp:string36Type" />
+                              <xs:element name="amount" type="xp:achTransactionAmountType" />
+                              <xs:element name="accountInfo" type="xp:echeckType" />
+                              <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                          </xs:sequence>
+                      </xs:choice>
+                  </xs:extension>
+              </xs:complexContent>
+          </xs:complexType>
+      </xs:element>
 
-    <xs:element name="submerchantDebit" substitutionGroup="xp:transaction">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
-                    <xs:choice>
-                        <xs:sequence>
-                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
-                            <xs:element name="submerchantName" type="xp:string256Type"/>
-                            <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:achTransactionAmountType" />
-                            <xs:element name="accountInfo" type="xp:echeckType" />
-                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
-                        </xs:sequence>
-                    </xs:choice>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+      <xs:element name="submerchantDebit" substitutionGroup="xp:transaction">
+          <xs:complexType>
+              <xs:complexContent>
+                  <xs:extension base="xp:transactionTypeWithReportGroup">
+                      <xs:choice>
+                          <xs:sequence>
+                              <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                              <xs:element name="submerchantName" type="xp:string256Type"/>
+                              <xs:element name="fundsTransferId" type="xp:string36Type" />
+                              <xs:element name="amount" type="xp:achTransactionAmountType" />
+                              <xs:element name="accountInfo" type="xp:echeckType" />
+                              <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                          </xs:sequence>
+                      </xs:choice>
+                  </xs:extension>
+              </xs:complexContent>
+          </xs:complexType>
+      </xs:element>
 
-    <xs:element name="customerCredit" substitutionGroup="xp:transaction">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
-                    <xs:choice>
-                        <xs:sequence>
-                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
-                            <xs:element name="customerName" type="xp:string256Type"/>
-                            <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
-                            <xs:element name="accountInfo" type="xp:echeckType" />
-                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
-                        </xs:sequence>
-                    </xs:choice>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+      <xs:element name="customerCredit" substitutionGroup="xp:transaction">
+          <xs:complexType>
+              <xs:complexContent>
+                  <xs:extension base="xp:transactionTypeWithReportGroup">
+                      <xs:choice>
+                          <xs:sequence>
+                              <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                              <xs:element name="customerName" type="xp:string256Type"/>
+                              <xs:element name="fundsTransferId" type="xp:string36Type" />
+                              <xs:element name="amount" type="xp:transactionAmountType" />
+                              <xs:element name="accountInfo" type="xp:echeckType" />
+                              <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                          </xs:sequence>
+                      </xs:choice>
+                  </xs:extension>
+              </xs:complexContent>
+          </xs:complexType>
+      </xs:element>
 
-    <xs:element name="customerDebit" substitutionGroup="xp:transaction">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="xp:transactionTypeWithReportGroup">
-                    <xs:choice>
-                        <xs:sequence>
-                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
-                            <xs:element name="customerName" type="xp:string256Type"/>
-                            <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
-                            <xs:element name="accountInfo" type="xp:echeckType" />
-                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
-                        </xs:sequence>
-                    </xs:choice>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>-->
+      <xs:element name="customerDebit" substitutionGroup="xp:transaction">
+          <xs:complexType>
+              <xs:complexContent>
+                  <xs:extension base="xp:transactionTypeWithReportGroup">
+                      <xs:choice>
+                          <xs:sequence>
+                              <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                              <xs:element name="customerName" type="xp:string256Type"/>
+                              <xs:element name="fundsTransferId" type="xp:string36Type" />
+                              <xs:element name="amount" type="xp:transactionAmountType" />
+                              <xs:element name="accountInfo" type="xp:echeckType" />
+                              <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                          </xs:sequence>
+                      </xs:choice>
+                  </xs:extension>
+              </xs:complexContent>
+          </xs:complexType>
+      </xs:element>-->
 
     <xs:element name="BNPLAuthorizationRequest" substitutionGroup="xp:transaction">
         <xs:complexType>
@@ -6045,5 +6116,24 @@
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="encryptionKeyRequest" type="xp:encryptionKeyRequestEnum"/>
+
+    <xs:element name="encryptionKeyResponse">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="encryptionKeySequence" type="xp:encryptionKeySequenceType" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="encryptionKey" type="xp:encryptionKeyType" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="encryptedPayload">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="encryptionKeySequence" type="xp:encryptionKeySequenceType" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="payload" type="xp:payloadType" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 
 </xs:schema>


### PR DESCRIPTION
= CnpOnline CHANGELOG

==Version 12.40.0 (v12.40.0)(October 25, 2024)
* Change: [cnpAPI v12.40] In authorization,sale and captureGivenAuth request new elements added-> 'typeOfDigitalCurrency' and 'conversionAffiliateId'.
* Change: [cnpAPI v12.40] In existing simple type transactionAmountType range added between minInclusive value -999999999999  and maxInclusive value 999999999999
* Change: [cnpAPI v12.40] In existing type authenticationProtocolVersionType new values '3','4','5','6','7','8' and '9' are added

==Version 12.39.0 (v12.39.0) (October 25, 2024)
* Change: [cnpAPI v12.39] In 'subMerchantCredit' 'payFacCredit','reserveCredit', 'payoutOrgCreditRequest' base changed from 'transactionTypeWithReportGroup' to 'transactionTypeWithReportGroupAndRtp'.
* Change: [cnpAPI v12.39] To support new changed extension base for above txns ,New Complextype 'transactionTypeWithReportGroupAndRtp' added.
* Change: [cnpAPI v12.39] New element 'fundingTransactionReferenceNumber' in authorization and sale response.

==Version 12.38.0 (v12.38.0) (October 25, 2024)
* Change: [cnpAPI v12.38] In existing Enum 'ActionTypeEnum' new value 'FIVD' added
* Change: [cnpAPI v12.38] In existing complex element 'baseRequest' two more choices are added 'encryptionKeyRequest' and 'encryptedPayload'
* Change: [cnpAPI v12.38] In existing complex element 'cnpOnlineResponse' one more choice is added 'encryptionKeyResponse'
* Change: [cnpAPI v12.38] New element 'encryptionKeyRequest' is added of type 'encryptionKeyRequestEnum'
* Change: [cnpAPI v12.38] To support 'encryptionKeyRequest' new Enum 'encryptionKeyRequestEnum' added with values 'CURRENT' and 'PREVIOUS'
* Change: [cnpAPI v12.38] New complex element 'encryptionKeyResponse' is added with simple elements ->'encryptionKeySequence' of type 'encryptionKeySequenceType' and 'encryptionKey' of type 'encryptionKeyType'
* Change: [cnpAPI v12.38] To support 'encryptionKeySequence' new simple type 'encryptionKeySequenceType' added with total Digits 19
* Change: [cnpAPI v12.38] To support 'encryptionKey' new simple type 'encryptionKeyType' of type string with maxLength 15000
* Change: [cnpAPI v12.38] New complex element 'encryptedPayload' is added with simple elements ->'encryptionKeySequence' of type 'encryptionKeySequenceType' and 'payload' of type 'payloadType'
* Change: [cnpAPI v12.38] To support 'payload' new simple type 'payloadType' of type string with maxLength 15000
* Change: [cnpAPI v12.38] In capture Request new complex element 'partialCapture' is added with elements-> 'partialCaptureSequenceNumber' of type 'integer' and 'partialCaptureTotalCount' of type 'partialCaptureCount'