### PR TITLE
commiting changes fr 12.46 and 12.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Change: [cnpAPI v12.47] New header 'X-Ecom-Api' is added in the request on the b
 Change: [cnpAPI v12.47] New enum 'numberOfPaymentsEnum' added with values '1','2','3','4','5','6','7','8','9','+','' .
 Change: [cnpAPI v12.47] New enum 'lineItemDetailIndicatorEnum' added with values '0','1','2','3','4','5'.
 Change: [cnpAPI v12.47] In existing complex element lineItemData new enum 'lineItemDetailIndicator' of type 'lineItemDetailIndicatorEnum' is added.
-Change: [cnpAPI v12.47] In existing complex element 'numberOfPayments' new enum 'numberOfPayments' of type 'numberOfPaymentsEnum' is added.
+Change: [cnpAPI v12.47] In existing complex element 'enhancedData' new enum 'numberOfPayments' of type 'numberOfPaymentsEnum' is added.
 Change: [cnpAPI v12.46] In 'AuthorizationResponse' and 'SaleResponse' simple elements 'credentialType' of type 'string' and 'cardDetails' of type 'ccAccountNumberType' are added.
 Change: [cnpAPI v12.46] In existing complex element 'accountFundingTransactionData' two simple elements 'receiverAccountNumber' of type 'string50Type' and 'receiverAccountNumberCnpToken' of type 'ccAccountNumberType' are added as choice.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 = CnpOnline CHANGELOG
 
+==Change Log for 12.47 (August 28,2025)
+Change: [cnpAPI v12.47] New header 'X-Ecom-Api' is added in the request on the basis 2 cofiguration newly added properties in the property file 'sendEcomHeader' and 'ecomHeaderValue'.
+Change: [cnpAPI v12.47] New enum 'numberOfPaymentsEnum' added with values '1','2','3','4','5','6','7','8','9','+','' .
+Change: [cnpAPI v12.47] New enum 'lineItemDetailIndicatorEnum' added with values '0','1','2','3','4','5'.
+Change: [cnpAPI v12.47] In existing complex element lineItemData new enum 'lineItemDetailIndicator' of type 'lineItemDetailIndicatorEnum' is added.
+Change: [cnpAPI v12.47] In existing complex element 'numberOfPayments' new enum 'numberOfPayments' of type 'numberOfPaymentsEnum' is added.
+Change: [cnpAPI v12.46] In 'AuthorizationResponse' and 'SaleResponse' simple elements 'credentialType' of type 'string' and 'cardDetails' of type 'ccAccountNumberType' are added.
+Change: [cnpAPI v12.46] In existing complex element 'accountFundingTransactionData' two simple elements 'receiverAccountNumber' of type 'string50Type' and 'receiverAccountNumberCnpToken' of type 'ccAccountNumberType' are added as choice.
+
 ==Change Log for 12.45 (May 27,2025)
 Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
 Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added.

--- a/cnp/sdk/Checker.php
+++ b/cnp/sdk/Checker.php
@@ -36,7 +36,7 @@ class Checker
     public static function validateXML($request){
         $xml = new DOMDocument();
         $xml->loadXML($request);
-        $filepath = __DIR__ . "/schema/SchemaCombined_v12.45.xsd";
+        $filepath = __DIR__ . "/schema/SchemaCombined_v12.47.xsd";
         $result =  $xml->schemaValidate( $filepath);
 
         if(!$result)

--- a/cnp/sdk/CnpOnline.php
+++ b/cnp/sdk/CnpOnline.php
@@ -24,9 +24,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 namespace cnp\sdk;
-define('CURRENT_XML_VERSION', '12.45');
-define('CURRENT_SDK_VERSION', 'PHP;12.45.0');
+define('CURRENT_XML_VERSION', '12.47');
+define('CURRENT_SDK_VERSION', 'PHP;12.47.0');
 define('MAX_TXNS_PER_BATCH', 100000);
 define('MAX_TXNS_PER_REQUEST', 500000);
-define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,neuter_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout,oltpEncryptionKeySequence,oltpEncryptionPayload,oltpEncryptionKeyPath');
+define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,neuter_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout,oltpEncryptionKeySequence,oltpEncryptionPayload,oltpEncryptionKeyPath,sendEcomHeader,ecomHeaderValue');
 

--- a/cnp/sdk/Communication.php
+++ b/cnp/sdk/Communication.php
@@ -25,7 +25,8 @@
 namespace cnp\sdk;
 class Communication
 {
-    public static function httpRequest($req,$hash_config=NULL)
+     const ECOM_API = '';
+     public static function httpRequest($req, $hash_config = NULL)
     {
         $config = Obj2xml::getConfig($hash_config);
 
@@ -38,7 +39,33 @@ class Communication
 
         curl_setopt($ch, CURLOPT_PROXY, $config['proxy']);
         curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: text/xml; charset=UTF-8','Expect: '));
+
+        $headers = [
+            'Content-type: text/xml; charset=UTF-8',
+            'Expect: '
+        ];
+
+// Always add the header if sendEcomHeader is true
+        if (isset($config['sendEcomHeader']) && filter_var($config['sendEcomHeader'], FILTER_VALIDATE_BOOLEAN)) {
+            // Get value from config
+            $ecomHeaderValue = isset($config['ecomHeaderValue']) ? trim($config['ecomHeaderValue']) : null;
+
+            // Fallback to class constant if config value is empty
+            if (empty($ecomHeaderValue) && defined(self::ECOM_API)) {
+                $ecomHeaderValue = self::ECOM_API;
+            }
+
+            if(empty($ecomHeaderValue)) {
+                $headers[] = 'X-Ecom-Api;';
+            }
+            else{
+                $headers[] = 'X-Ecom-Api:' . $ecomHeaderValue;
+            }
+        }
+// Set headers after building them
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+
         $commManager = CommManager::instance($config);
         $requestTarget = $commManager->findUrl();
 

--- a/cnp/sdk/Communication.php
+++ b/cnp/sdk/Communication.php
@@ -51,7 +51,7 @@ class Communication
             $ecomHeaderValue = isset($config['ecomHeaderValue']) ? trim($config['ecomHeaderValue']) : null;
 
             // Fallback to class constant if config value is empty
-            if (empty($ecomHeaderValue) && defined(self::ECOM_API)) {
+            if ($ecomHeaderValue==='' && defined('self::ECOM_API')) {
                 $ecomHeaderValue = self::ECOM_API;
             }
 

--- a/cnp/sdk/Obj2xml.php
+++ b/cnp/sdk/Obj2xml.php
@@ -339,7 +339,7 @@ class Obj2xml
                 } elseif ($name == 'sftp_timeout') {
                     $config['sftp_timeout'] = isset($config_array['sftp_timeout'])? $config_array['sftp_timeout']:'720';
                 } else {
-                    if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload') and ($name != 'oltpEncryptionKeySequence') and ($name != 'oltpEncryptionKeyPath') and ($name != 'neuter_xml')) {
+                    if ((!isset($config_array[$name])) and ($name != 'proxy') and ($name != 'oltpEncryptionPayload') and ($name != 'oltpEncryptionKeySequence') and ($name != 'oltpEncryptionKeyPath') and ($name != 'neuter_xml') and ($name != 'sendEcomHeader') and ($name != 'ecomHeaderValue')) {
                         throw new \InvalidArgumentException("Missing Field /$name/");
                     }
                     // If encryptionPayload properties are not available in config file then add other properties.

--- a/cnp/sdk/Setup.php
+++ b/cnp/sdk/Setup.php
@@ -147,6 +147,18 @@ function initialize()
             $line['oltpEncryptionKeyPath '] = "";
         }
 
+        print "Please input your sendEcomHeader (true/false) (by default values is false): ";
+        $sendEcomHeader = trim(fgets(STDIN));
+        $line['sendEcomHeader'] = $sendEcomHeader;
+        $booleanSendEcomHeaderValue = filter_var(strtolower($sendEcomHeader), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if  ($booleanSendEcomHeaderValue){
+            print "Please input your ecomHeaderValue: ";
+            $line['ecomHeaderValue'] = formatConfigValue(STDIN);
+        }else{
+            $line['sendEcomHeader'] = "false";
+            $line['ecomHeaderValue'] = "";
+        }
+
         writeConfig($line,$handle);
         #default http timeout set to 500 ms
         fwrite($handle, "timeout =  500".  PHP_EOL);

--- a/cnp/sdk/Test/functional/AuthFunctionalTest.php
+++ b/cnp/sdk/Test/functional/AuthFunctionalTest.php
@@ -53,7 +53,8 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
                 'receiverLastName' =>'Smith',
                 'receiverState' => 'AZ',
                 'receiverCountry' => 'USA',
-                'receiverAccountNumber' => '1234567890',
+              /*  'receiverAccountNumber' => '1234567890',*/
+                'receiverAccountNumberCnpToken' => '12344444444444',
                 'accountFundingTransactionType' => 'walletTransfer',
                 'receiverAccountNumberType' => 'cardAccount'
                 ),
@@ -902,6 +903,7 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
                     'unitOfMeasure' => 'EACH',
                     'lineItemTotal' => '9900',
                     'lineItemTotalWithTax' => '10000',
+                    'lineItemDetailIndicator'=>'0',
                     'itemDiscountAmount' => '0',
                     'commodityCode' => '301',
                     'unitCost' => '31.02',
@@ -920,6 +922,7 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
                 'discountCode' => 'OneTimeDiscount11',
                 'discountPercent' => '11',
                 'fulfilmentMethodType' => 'DELIVERY',
+                'numberOfPayments' => '',
             ),
             'lodgingInfo' => array(
                 'bookingID' => 'book1234512341',

--- a/cnp/sdk/Test/functional/SaleFunctionalTest.php
+++ b/cnp/sdk/Test/functional/SaleFunctionalTest.php
@@ -1086,6 +1086,7 @@ class SaleFunctionalTest extends \PHPUnit_Framework_TestCase
                     'unitOfMeasure' => 'EACH',
                     'lineItemTotal' => '9900',
                     'lineItemTotalWithTax' => '10000',
+                    'lineItemDetailIndicator'=>'0',
                     'itemDiscountAmount' => '0',
                     'commodityCode' => '301',
                     'unitCost' => '31.02',
@@ -1095,6 +1096,7 @@ class SaleFunctionalTest extends \PHPUnit_Framework_TestCase
                 'discountCode' => 'OneTimeDiscount11',
                 'discountPercent' => '11',
                 'fulfilmentMethodType' => 'STANDARD_SHIPPING',
+                'numberOfPayments' => '+',
             ),
             'lodgingInfo' => array(
                 'bookingID' => 'book1234512341',

--- a/cnp/sdk/Test/unit/AuthUnitTest.php
+++ b/cnp/sdk/Test/unit/AuthUnitTest.php
@@ -824,6 +824,57 @@ class AuthUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->authorizationRequest($hash_in);
     }
 
+    public function test_auth_with_enhancedData()
+    {
+        $hash_in = array(
+            'id' => 'id',
+            'orderId' => '82364_cnpApiAuth',
+            'amount' => '1001',
+            'orderSource' => 'telephone',
+            'card' => array(
+                'type' => 'VI',
+                'number' => '4005518220000002',
+                'expDate' => '0150',
+                'cardValidationNum' => '987',
+            ),
+            'enhancedData' => array(
+                'customerReference' => 'cust ref sale1',
+                'salesTax' => '1000',
+                'discountAmount' => '0',
+                'shippingAmount' => '0',
+                'dutyAmount' => '0',
+                'lineItemData' => array(
+                    'itemSequenceNumber' => '1',
+                    'itemDescription' => 'Clothes',
+                    'productCode' => 'TB123',
+                    'lineItemTotalWithTax' => '10000',
+                    'lineItemDetailIndicator'=>'0',
+                    'itemDiscountAmount' => '0',
+                    'commodityCode' => '301',
+                    'unitCost' => '31.02',
+                    'itemCategory' => 'Aparel',
+                    'itemSubCategory' => 'Clothing',
+                ),
+                'numberOfPayments' => '5',
+            ),
+            'orderChannel' => 'PHONE',
+            'fraudCheckStatus' => 'CLOSE',
+            'overridePolicy' => 'merchantPolicyToDecline',
+            'fsErrorCode' => 'error123',
+            'merchantAccountStatus' => 'activeAccount',
+            'productEnrolled' => 'GUARPAY3',
+            'decisionPurpose' => 'CONSIDER_DECISION',
+            'fraudSwitchIndicator' => 'POST',
+        );
 
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<enhancedData>.*<lineItemData>.*<lineItemDetailIndicator>0.*<numberOfPayments>5.*POST.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->authorizationRequest($hash_in);
+    }
 
 }

--- a/cnp/sdk/XmlFields.php
+++ b/cnp/sdk/XmlFields.php
@@ -321,6 +321,7 @@ class XmlFields
                 "taxAmount" => XmlFields::returnArrayValue($hash_in, "taxAmount"),
                 "lineItemTotal" => XmlFields::returnArrayValue($hash_in, "lineItemTotal"),
                 "lineItemTotalWithTax" => XmlFields::returnArrayValue($hash_in, "lineItemTotalWithTax"),
+                "lineItemDetailIndicator" => XmlFields::returnArrayValue($hash_in, "lineItemDetailIndicator"),
                 "itemDiscountAmount" => XmlFields::returnArrayValue($hash_in, "itemDiscountAmount"),
                 "commodityCode" => XmlFields::returnArrayValue($hash_in, "commodityCode"),
                 "unitCost" => XmlFields::returnArrayValue($hash_in, "unitCost"),
@@ -376,7 +377,8 @@ class XmlFields
                 array(
                     "discountCode" => XmlFields::returnArrayValue($hash_in, "discountCode"),
                     "discountPercent" => XmlFields::returnArrayValue($hash_in, "discountPercent"),
-                    "fulfilmentMethodType" => XmlFields::returnArrayValue($hash_in, "fulfilmentMethodType")
+                    "fulfilmentMethodType" => XmlFields::returnArrayValue($hash_in, "fulfilmentMethodType"),
+                    "numberOfPayments" => XmlFields::returnArrayValue($hash_in, "numberOfPayments")
                     )
             );
             return $hash_out;
@@ -1101,6 +1103,7 @@ class XmlFields
                 "receiverCountry" => XmlFields::returnArrayValue($hash_in, 'receiverCountry'),
                 "receiverAccountNumberType" => XmlFields::returnArrayValue($hash_in, 'receiverAccountNumberType'),
                 "receiverAccountNumber" => XmlFields::returnArrayValue($hash_in, 'receiverAccountNumber'),
+                "receiverAccountNumberCnpToken" => XmlFields::returnArrayValue($hash_in, 'receiverAccountNumberCnpToken'),
                 "accountFundingTransactionType" => XmlFields::returnArrayValue($hash_in, 'accountFundingTransactionType'),
             );
 

--- a/cnp/sdk/schema/SchemaCombined_v12.47.xsd
+++ b/cnp/sdk/schema/SchemaCombined_v12.47.xsd
@@ -1301,6 +1301,34 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="numberOfPaymentsEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+            <xs:enumeration value="6"/>
+            <xs:enumeration value="7"/>
+            <xs:enumeration value="8"/>
+            <xs:enumeration value="9"/>
+            <xs:enumeration value="+"/>
+            <xs:enumeration value=""/>
+        </xs:restriction>
+    </xs:simpleType>
+
+
+    <xs:simpleType name="lineItemDetailIndicatorEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+            <xs:enumeration value="3"/>
+            <xs:enumeration value="4"/>
+            <xs:enumeration value="5"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="orderChannelEnum">
         <xs:restriction base="xs:string">
             <xs:enumeration value="WEB" />
@@ -2452,6 +2480,7 @@
                 <xs:element name="discountCode" type="xp:string100Type" minOccurs="0"/>
                 <xs:element name="discountPercent" type="xp:discountPercentType" minOccurs="0"/>
                 <xs:element name="fulfilmentMethodType" type="xp:fulfilmentMethodTypeEnum" minOccurs="0"/>
+                <xs:element name="numberOfPayments" type="xp:numberOfPaymentsEnum" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -2481,6 +2510,7 @@
                 <!-- quantity * unit cost -->
                 <xs:element name="lineItemTotalWithTax" type="xp:transactionAmountType" minOccurs="0"/>
                 <!-- line item total + tax -->
+                <xs:element name="lineItemDetailIndicator" type="xp:lineItemDetailIndicatorEnum" minOccurs="0"/>
                 <xs:element name="itemDiscountAmount" type="xp:transactionAmountType" minOccurs="0"/>
                 <xs:element name="commodityCode" type="xp:commodityCodeType" minOccurs="0"/>
                 <xs:element name="unitCost" type="xp:unitCostType" minOccurs="0"/>
@@ -2677,6 +2707,8 @@
                         <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0"/>
                         <!--If AuthMax is used -->
                         <xs:element ref="xp:authMax" minOccurs="0"/>
+                        <xs:element name="credentialType" type="xp:string3Type" minOccurs="0"/>
+                        <xs:element name="cardDetails" type="xp:ccAccountNumberType" minOccurs="0"/>
                         <xs:element name="fundingTransactionReferenceNumber" type="xp:string19Type" minOccurs="0"/>
                         <xs:element name="retrievalReferenceNumber" type="xp:string12Type" minOccurs="0"/>
                         <xs:element name="orderSource" type="xp:orderSourceType" minOccurs="0"/>
@@ -3146,6 +3178,8 @@
                         <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0"/>
                         <!--If AuthMax is used -->
                         <xs:element ref="xp:authMax" minOccurs="0"/>
+                        <xs:element name="credentialType" type="xp:string3Type" minOccurs="0"/>
+                        <xs:element name="cardDetails" type="xp:ccAccountNumberType" minOccurs="0"/>
                         <xs:element name="fundingTransactionReferenceNumber" type="xp:string19Type" minOccurs="0"/>
                         <xs:element name="retrievalReferenceNumber" type="xp:string12Type" minOccurs="0"/>
                         <xs:element name="orderSource" type="xp:orderSourceType" minOccurs="0"/>
@@ -5087,7 +5121,10 @@
                 <xs:element name="receiverState" type="xp:stateTypeEnum" minOccurs="0"/>
                 <xs:element name="receiverCountry" type="xp:countryTypeEnum" minOccurs="0"/>
                 <xs:element name="receiverAccountNumberType" type="xp:accountFundingTransactionAccountNumberTypeEnum" minOccurs="0"/>
-                <xs:element name="receiverAccountNumber" type="xp:string50Type" minOccurs="0"/>
+                <xs:choice>
+                    <xs:element name="receiverAccountNumber" type="xp:string50Type" minOccurs="0"/>
+                    <xs:element name="receiverAccountNumberCnpToken" type="xp:ccAccountNumberType" minOccurs="0"/>
+                </xs:choice>
                 <xs:element name="accountFundingTransactionType" type="xp:accountFundingTransactionTypeEnum" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
@@ -5146,7 +5183,7 @@
         </xs:complexType>
     </xs:element>
 
-        <!--cnpBatch-->
+    <!--cnpBatch-->
 
     <!--    <xs:include schemaLocation="cnpTransaction_v12.24.xsd" />-->
 


### PR DESCRIPTION
- Change: [cnpAPI v12.47] New header 'X-Ecom-Api' is added in the request on the basis 2 cofiguration newly added properties in the property file 'sendEcomHeader' and 'ecomHeaderValue'.
- Change: [cnpAPI v12.47] New enum 'numberOfPaymentsEnum' added with values '1','2','3','4','5','6','7','8','9','+','' .
- Change: [cnpAPI v12.47] New enum 'lineItemDetailIndicatorEnum' added with values '0','1','2','3','4','5'.
- Change: [cnpAPI v12.47] In existing complex element lineItemData new enum 'lineItemDetailIndicator' of type 'lineItemDetailIndicatorEnum' is added.
- Change: [cnpAPI v12.47] In existing complex element 'numberOfPayments' new enum 'numberOfPayments' of type 'numberOfPaymentsEnum' is added.
- Change: [cnpAPI v12.46] In 'AuthorizationResponse' and 'SaleResponse' simple elements 'credentialType' of type 'string' and 'cardDetails' of type 'ccAccountNumberType' are added.
- Change: [cnpAPI v12.46] In existing complex element 'accountFundingTransactionData' two simple elements 'receiverAccountNumber' of type 'string50Type' and 'receiverAccountNumberCnpToken' of type 'ccAccountNumberType' are added as choice.
