### PR TITLE
V12.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 = CnpOnline CHANGELOG
 
+==Change Log for 12.48 (January 8,2026)
+Change: [cnpAPI v12.48] New element pazeEncryptedPayload added to both Auth and Sale transaction requests.
+Change: [cnpAPI v12.48] New complex element TLID added in authResponse and authReversalResponse.
+Change: [cnpAPI v12.48] New sub elements to support TLID - lifecycleTlid (type: tlidType),economicTlid (type: tlidType),tlidCustomerProvided (type: tlidType) and tlidValidationActionIndicator (type: tlidValidationActionIndicatorType).
+Change: [cnpAPI v12.48] New element tlidValidationActionIndicatorType added with Enum values 1, 2.
+Change: [cnpAPI v12.48] New type tlidType added as string for TLID fields.
+
 ==Change Log for 12.47 (August 28,2025)
 Change: [cnpAPI v12.47] New header 'X-Ecom-Api' is added in the request on the basis 2 cofiguration newly added properties in the property file 'sendEcomHeader' and 'ecomHeaderValue'.
 Change: [cnpAPI v12.47] New enum 'numberOfPaymentsEnum' added with values '1','2','3','4','5','6','7','8','9','+','' .

--- a/cnp/sdk/Checker.php
+++ b/cnp/sdk/Checker.php
@@ -36,7 +36,7 @@ class Checker
     public static function validateXML($request){
         $xml = new DOMDocument();
         $xml->loadXML($request);
-        $filepath = __DIR__ . "/schema/SchemaCombined_v12.47.xsd";
+        $filepath = __DIR__ . "/schema/SchemaCombined_v12.48.xsd";
         $result =  $xml->schemaValidate( $filepath);
 
         if(!$result)

--- a/cnp/sdk/CnpOnline.php
+++ b/cnp/sdk/CnpOnline.php
@@ -24,8 +24,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 namespace cnp\sdk;
-define('CURRENT_XML_VERSION', '12.47');
-define('CURRENT_SDK_VERSION', 'PHP;12.47.0');
+define('CURRENT_XML_VERSION', '12.48');
+define('CURRENT_SDK_VERSION', 'PHP;12.48.0');
 define('MAX_TXNS_PER_BATCH', 100000);
 define('MAX_TXNS_PER_REQUEST', 500000);
 define('CNP_CONFIG_LIST', 'user,password,merchantId,timeout,proxy,reportGroup,version,url,cnp_requests_path,batch_requests_path,sftp_username,sftp_password,batch_url,tcp_port,tcp_ssl,tcp_timeout,print_xml,neuter_xml,vantivPublicKeyID,gpgPassphrase,useEncryption,deleteBatchFiles,multiSite,multiSiteErrorThreshold,maxHoursWithoutSwitch,printMultiSiteDebug,multiSiteUrl1,multiSiteUrl2,sftp_timeout,oltpEncryptionKeySequence,oltpEncryptionPayload,oltpEncryptionKeyPath,sendEcomHeader,ecomHeaderValue');

--- a/cnp/sdk/CnpOnlineRequest.php
+++ b/cnp/sdk/CnpOnlineRequest.php
@@ -116,6 +116,7 @@ class CnpOnlineRequest
                 'paypage' => (XmlFields::cardPaypageType(XmlFields::returnArrayValue($hash_in, 'paypage'))),
                 'applepay' => (XmlFields::applepayType(XmlFields::returnArrayValue($hash_in, 'applepay'))),
                 'mpos' => (XmlFields::mposType(XmlFields::returnArrayValue($hash_in, 'mpos'))),
+                'pazeEncryptedPayload' => XmlFields::returnArrayValue($hash_in, 'pazeEncryptedPayload',7500),
                 'billMeLaterRequest' => (XmlFields::billMeLaterRequest(XmlFields::returnArrayValue($hash_in, 'billMeLaterRequest'))),
                 'cardholderAuthentication' => (XmlFields::fraudCheckType(XmlFields::returnArrayValue($hash_in, 'cardholderAuthentication'))),
                 'processingInstructions' => (XmlFields::processingInstructions(XmlFields::returnArrayValue($hash_in, 'processingInstructions'))),
@@ -161,7 +162,7 @@ class CnpOnlineRequest
                 'originalRetrievalReferenceNumber' => XmlFields::returnArrayValue($hash_in, 'originalRetrievalReferenceNumber'),
             );
         }
-        $choice_hash = array(XmlFields::returnArrayValue($hash_out, 'card'), XmlFields::returnArrayValue($hash_out, 'paypal'), XmlFields::returnArrayValue($hash_out, 'token'), XmlFields::returnArrayValue($hash_out, 'paypage'), XmlFields::returnArrayValue($hash_out, 'applepay'), XmlFields::returnArrayValue($hash_out, 'mpos'));
+        $choice_hash = array(XmlFields::returnArrayValue($hash_out, 'card'), XmlFields::returnArrayValue($hash_out, 'paypal'), XmlFields::returnArrayValue($hash_out, 'token'), XmlFields::returnArrayValue($hash_out, 'paypage'), XmlFields::returnArrayValue($hash_out, 'applepay'), XmlFields::returnArrayValue($hash_out, 'mpos'),XmlFields::returnArrayValue($hash_out, 'pazeEncryptedPayload'));
         $authorizationResponse = $this->processRequest($hash_out, $hash_in, 'authorization', $choice_hash);
 
         return $authorizationResponse;
@@ -198,6 +199,7 @@ class CnpOnlineRequest
             'giropay' => (XmlFields::giropayType(XmlFields::returnArrayValue($hash_in, 'giropay'))),
             'sofort' => (XmlFields::sofortType(XmlFields::returnArrayValue($hash_in, 'sofort'))),
             'mpos' => (XmlFields::mposType(XmlFields::returnArrayValue($hash_in, 'mpos'))),
+            'pazeEncryptedPayload' => XmlFields::returnArrayValue($hash_in, 'pazeEncryptedPayload',7500),
             'billMeLaterRequest' => XmlFields::billMeLaterRequest(XmlFields::returnArrayValue($hash_in, 'billMeLaterRequest')),
             'fraudCheck' => XmlFields::fraudCheckType(XmlFields::returnArrayValue($hash_in, 'fraudCheck')),
             'cardholderAuthentication' => XmlFields::fraudCheckType(XmlFields::returnArrayValue($hash_in, 'cardholderAuthentication')),
@@ -246,7 +248,8 @@ class CnpOnlineRequest
             'identityBundle' => (XmlFields::identityBundle(XmlFields::returnArrayValue($hash_in, 'identityBundle'))),
         );
 
-        $choice_hash = array($hash_out['card'], $hash_out['paypal'], $hash_out['token'], $hash_out['paypage'], $hash_out['applepay'], $hash_out['mpos']);
+      //  $choice_hash = array($hash_out['card'], $hash_out['paypal'], $hash_out['token'], $hash_out['paypage'], $hash_out['applepay'], $hash_out['mpos'],$hash_out['pazeEncryptedPayload']);
+        $choice_hash = array(XmlFields::returnArrayValue($hash_out, 'card'), XmlFields::returnArrayValue($hash_out, 'paypal'), XmlFields::returnArrayValue($hash_out, 'token'), XmlFields::returnArrayValue($hash_out, 'paypage'), XmlFields::returnArrayValue($hash_out, 'applepay'), XmlFields::returnArrayValue($hash_out, 'mpos'),XmlFields::returnArrayValue($hash_out, 'pazeEncryptedPayload'));
         $choice2_hash = array($hash_out['fraudCheck'], $hash_out['cardholderAuthentication']);
         $saleResponse = $this->processRequest($hash_out, $hash_in, 'sale', $choice_hash, $choice2_hash);
 

--- a/cnp/sdk/Test/functional/AuthFunctionalTest.php
+++ b/cnp/sdk/Test/functional/AuthFunctionalTest.php
@@ -1479,4 +1479,45 @@ class AuthFunctionalTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sandbox', $location);
     }
 
+    public function test_pazeEncryptedPayload_auth()
+    {
+        $hash_in = array('id' => 'id',
+            'pazeEncryptedPayload'=>'NDEwMDAwMDAwMDAwMDAwMA==',
+            'id' => '1211',
+            'orderId' => '22@33',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerceDataOnly',
+            'businessIndicator'=>'agentCashOut',
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Smith',
+                'receiverState' => 'AZ',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '1234567890',
+                'accountFundingTransactionType' => 'walletTransfer',
+                'receiverAccountNumberType' => 'cardAccount'
+            ),
+            'amount' => '1512',
+            'oltpEncryptionPayload' => false,
+            'identityBundle' => array(
+                'merchantId' => '12222',
+                'entityId' => '234567',
+                'entityReference' => '23475',
+                'resourceId' => '67806',
+                'resourceReference' => '231457',
+                'commandId' => '09765',
+                'commandReference' => '5679',
+                'orderReference' => '223555',
+            ),
+            'originalRetrievalReferenceNumber' => '345378'
+
+        );
+
+        $initialize = new CnpOnlineRequest();
+        $authorizationResponse = $initialize->authorizationRequest($hash_in);
+        $response = XmlParser::getNode($authorizationResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($authorizationResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
 }

--- a/cnp/sdk/Test/functional/SaleFunctionalTest.php
+++ b/cnp/sdk/Test/functional/SaleFunctionalTest.php
@@ -1567,10 +1567,45 @@ class SaleFunctionalTest extends \PHPUnit_Framework_TestCase
             'fraudCheckAction' => 'APPROVED_SKIP_FRAUD_CHECK',
             'amount' => '123',
             'businessIndicator'=>'businessToBusinessTransfer',
-            'card' => array(
-                'type' => 'VI',
-                'number' => '4100000000000000',
-                'expDate' => '1210'),
+            'accountFundingTransactionData' => array(
+                'receiverLastName' =>'Jon',
+                'receiverState' => 'CA',
+                'receiverCountry' => 'USA',
+                'receiverAccountNumber' => '4356872257i',
+                'accountFundingTransactionType' => 'businessDisbursement',
+                'receiverAccountNumberType' => 'RTNAndBAN'),
+            'oltpEncryptionPayload' => false,
+            'identityBundle' => array(
+                'merchantId' => '12222',
+                'entityId' => '234567',
+                'entityReference' => '23475',
+                'resourceId' => '67806',
+                'resourceReference' => '231457',
+                'commandId' => '09765',
+                'commandReference' => '5679',
+                'orderReference' => '223555',
+            ),);
+
+        $initialize = new CnpOnlineRequest();
+        $saleResponse = $initialize->saleRequest($hash_in);
+        $response = XmlParser::getNode($saleResponse, 'response');
+        $this->assertEquals('000', $response);
+        $location = XmlParser::getNode($saleResponse, 'location');
+        $this->assertEquals('sandbox', $location);
+    }
+
+    public function test_sale_with_pazeEncryptedPayload()
+    {
+        $hash_in = array(
+            'pazeEncryptedPayload'=>'NTEwMDAwMDAwMDAwMDAwMA==',
+            'id' => '1211',
+            'orderId' => '2111',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerceDataOnly',
+            'orderChannel' => 'SCAN_AND_GO',
+            'fraudCheckAction' => 'APPROVED_SKIP_FRAUD_CHECK',
+            'amount' => '123',
+            'businessIndicator'=>'businessToBusinessTransfer',
             'accountFundingTransactionData' => array(
                 'receiverLastName' =>'Jon',
                 'receiverState' => 'CA',

--- a/cnp/sdk/Test/unit/AuthUnitTest.php
+++ b/cnp/sdk/Test/unit/AuthUnitTest.php
@@ -877,4 +877,53 @@ class AuthUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->authorizationRequest($hash_in);
     }
 
+    public function test_simple_auth_with_pazeEncryptedPayload()
+    {
+        $hash_in = array('id' => 'id',
+            'pazeEncryptedPayload'=>'NDEwMDAwMDAwMDAwMDAwMA==',
+            'id' => '1211',
+            'orderId' => '22@33',
+            'reportGroup' => 'Planets',
+            'orderSource' => 'ecommerce',
+            'amount' => '0',
+            'enhancedData' => array(
+                'detailTax0' => array(
+                    'taxAmount' => '200',
+                    'taxRate' => '0.06',
+                    'taxIncludedInTotal' => true
+                ),
+                'detailTax1' => array(
+                    'taxAmount' => '300',
+                    'taxRate' => '0.10',
+                    'taxIncludedInTotal' => true
+                ),'lineItemData0' => array(
+                    'itemSequenceNumber' => '1',
+                    'itemDescription' => 'product 1',
+                    'productCode' => '123',
+                    'quantity' => 3,
+                    'unitOfMeasure' => 'unit',
+                    'taxAmount' => 200,
+                    'detailTax' => array(
+                        'taxIncludedInTotal' => true,
+                        'taxAmount' => 200
+                    ),
+                    'itemCategory' => 'Aparel',
+                    'itemSubCategory' => 'Clothing',
+                    'productId' => '1001',
+                    'productName' => 'N1',
+                ))
+
+        );
+
+
+
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock	->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<pazeEncryptedPayload>NDEwMDAwMDAwMDAwMDAwMA==.*/'));
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->authorizationRequest($hash_in);
+    }
+
 }

--- a/cnp/sdk/Test/unit/SaleUnitTest.php
+++ b/cnp/sdk/Test/unit/SaleUnitTest.php
@@ -1418,5 +1418,36 @@ class SaleUnitTest extends \PHPUnit_Framework_TestCase
         $cnpTest->saleRequest($hash_in);
     }
 
+    public function test_sale_with_pazeEncryptedPayload()
+    {
+        $hash_in = array(
+            'pazeEncryptedPayload'=>'NDEwMDAwMDAwMDAwMDAwMA==',
+            'id'=>'654',
+            'orderId'=> '2111',
+            'orderSource'=>'ecommerce',
+            'amount'=>'123',
+            'processingType' => 'accountFunding',
+            'originalNetworkTransactionId' => 'abcdefgh',
+            'originalTransactionAmount' => '1000',
+            'identityBundle' => array(
+                'merchantId' => '12222',
+                'entityId' => '234567',
+                'entityReference' => '23475',
+                'resourceId' => '67806',
+                'resourceReference' => '231457',
+                'commandId' => '09765',
+                'commandReference' => '5679',
+                'orderReference' => '223555',
+            )
+        );
+        $mock = $this->getMock('cnp\sdk\CnpXmlMapper');
+        $mock->expects($this->once())
+            ->method('request')
+            ->with($this->matchesRegularExpression('/.*<pazeEncryptedPayload>NDEwMDAwMDAwMDAwMDAwMA==.*/'));
+
+        $cnpTest = new CnpOnlineRequest();
+        $cnpTest->newXML = $mock;
+        $cnpTest->saleRequest($hash_in);
+    }
 
 }

--- a/cnp/sdk/schema/SchemaCombined_v12.48.xsd
+++ b/cnp/sdk/schema/SchemaCombined_v12.48.xsd
@@ -2,7 +2,6 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
     <!--cnpCommon-->
-
     <xs:element name="authentication">
         <xs:complexType>
             <xs:sequence>
@@ -242,6 +241,13 @@
             <xs:maxLength value="1" />
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:simpleType name="stringTypeForPazeEncryptedPayload">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="7500" />
+        </xs:restriction>
+    </xs:simpleType>
+
 
     <xs:simpleType name="methodOfPaymentTypeEnum">
         <xs:restriction base="xs:string">
@@ -1477,7 +1483,7 @@
 
     <!--cnpRecurring-->
 
-    <!--<xs:include schemaLocation=cnpCommon_v12.45.xsd />-->
+   <!-- <xs:include schemaLocation="cnpCommon_v12.48.xsd" />-->
 
     <xs:element name="recurringTransaction" type="xp:recurringTransactionType" abstract="true" />
     <xs:element name="recurringTransactionResponse" type="xp:recurringTransactionResponseType" abstract="true" />
@@ -1932,6 +1938,7 @@
                                 <xs:element name="token" type="xp:cardTokenType"/>
                                 <xs:element name="paypage" type="xp:cardPaypageType"/>
                                 <xs:element name="applepay" type="xp:applepayType"/>
+                                <xs:element name="pazeEncryptedPayload" type="xp:stringTypeForPazeEncryptedPayload"/>
                             </xs:choice>
                             <xs:element name="cardholderAuthentication" type="xp:fraudCheckType" minOccurs="0"/>
                             <xs:element ref="xp:processingInstructions" minOccurs="0"/>
@@ -2176,6 +2183,7 @@
                             <xs:element name="ideal" type="xp:idealType"/>
                             <xs:element name="giropay" type="xp:giropayType"/>
                             <xs:element name="sofort" type="xp:sofortType"/>
+                            <xs:element name="pazeEncryptedPayload" type="xp:stringTypeForPazeEncryptedPayload"/>
                         </xs:choice>
                         <!-- fraudCheck is not used in the mapping -->
 
@@ -2712,6 +2720,7 @@
                         <xs:element name="fundingTransactionReferenceNumber" type="xp:string19Type" minOccurs="0"/>
                         <xs:element name="retrievalReferenceNumber" type="xp:string12Type" minOccurs="0"/>
                         <xs:element name="orderSource" type="xp:orderSourceType" minOccurs="0"/>
+                        <xs:element ref="xp:tlid" minOccurs="0"/>
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -2889,6 +2898,7 @@
                         <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
                         <!-- Introduced as part of Guaranteed Payments -->
                         <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0"/>
+                        <xs:element ref="xp:tlid" minOccurs="0"/>
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -3763,6 +3773,18 @@
             <xs:enumeration value="7"/>
             <xs:enumeration value="8"/>
             <xs:enumeration value="9"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="tlidValidationActionIndicatorType">
+        <xs:restriction base="xs:integer">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="tlidType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="22"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -5051,6 +5073,17 @@
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="tlid">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="lifecycleTlid" type="xp:tlidType" minOccurs="0"/>
+                <xs:element name="economicTlid" type="xp:tlidType" minOccurs="0"/>
+                <xs:element name="tlidValidationActionIndicator" type="xp:tlidValidationActionIndicatorType" minOccurs="0"/>
+                <xs:element name="tlidCustomerProvided" type="xp:tlidType" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
     <xs:element name="sellerInfo">
         <xs:complexType>
             <xs:all>
@@ -5185,7 +5218,7 @@
 
     <!--cnpBatch-->
 
-    <!--    <xs:include schemaLocation="cnpTransaction_v12.24.xsd" />-->
+<!--    <xs:include schemaLocation="cnpTransaction_v12.48.xsd" />-->
 
     <xs:element name="cnpRequest">
         <xs:complexType>
@@ -5591,7 +5624,7 @@
 
     <!--cnpOnline-->
 
-    <!--    <xs:include schemaLocation="cnpTransaction_v12.24.xsd" />-->
+    <!--<xs:include schemaLocation="cnpTransaction_v12.48.xsd" />-->
 
     <xs:complexType name="baseRequest">
         <xs:sequence>
@@ -5899,7 +5932,7 @@
         </xs:complexType>
     </xs:element>
 
-    <!--  <xs:element name="vendorCredit" substitutionGroup="xp:transaction">
+ <!--   <xs:element name="vendorCredit" substitutionGroup="xp:transaction">
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">


### PR DESCRIPTION
- Change: [cnpAPI v12.48] New element pazeEncryptedPayload added to both Auth and Sale transaction requests.
- Change: [cnpAPI v12.48] New complex element TLID added in authResponse and authReversalResponse.
- Change: [cnpAPI v12.48] New sub elements to support TLID - lifecycleTlid (type: tlidType),economicTlid (type: tlidType),tlidCustomerProvided (type: tlidType) and tlidValidationActionIndicator (type: tlidValidationActionIndicatorType).
- Change: [cnpAPI v12.48] New element tlidValidationActionIndicatorType added with Enum values 1, 2.
- Change: [cnpAPI v12.48] New type tlidType added as string for TLID fields.